### PR TITLE
fix(macos): reliably hide dock icon on all minimize-to-tray paths

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2459,6 +2459,8 @@ version = "2.3.1"
 dependencies = [
  "igd-next",
  "log",
+ "objc2",
+ "objc2-app-kit",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -2666,10 +2668,17 @@ checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
  "bitflags 2.11.0",
  "block2",
+ "libc",
  "objc2",
+ "objc2-cloud-kit",
+ "objc2-core-data",
  "objc2-core-foundation",
  "objc2-core-graphics",
+ "objc2-core-image",
+ "objc2-core-text",
+ "objc2-core-video",
  "objc2-foundation",
+ "objc2-quartz-core",
 ]
 
 [[package]]
@@ -2689,6 +2698,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b402a653efbb5e82ce4df10683b6b28027616a2715e90009947d50b8dd298fa"
 dependencies = [
+ "bitflags 2.11.0",
  "objc2",
  "objc2-foundation",
 ]
@@ -2747,6 +2757,19 @@ dependencies = [
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
+]
+
+[[package]]
+name = "objc2-core-video"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d425caf1df73233f29fd8a5c3e5edbc30d2d4307870f802d18f00d83dc5141a6"
+dependencies = [
+ "bitflags 2.11.0",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-graphics",
+ "objc2-io-surface",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -36,3 +36,7 @@ url = "2.5.8"
 tauri-plugin-window-state = "2.4.1"
 igd-next = { version = "0.15", features = ["aio_tokio"] }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"] }
+
+[target.'cfg(target_os = "macos")'.dependencies]
+objc2-app-kit = { version = "0.3", features = ["NSApplication", "NSRunningApplication"] }
+objc2 = "0.6"

--- a/src-tauri/src/commands/app.rs
+++ b/src-tauri/src/commands/app.rs
@@ -236,6 +236,11 @@ pub fn update_dock_badge(app: AppHandle, label: String) -> Result<(), AppError> 
 /// Toggles the macOS Dock icon visibility at runtime.
 /// `Accessory` hides the icon (menu-bar-only mode); `Regular` restores it.
 /// No-op on non-macOS platforms.
+///
+/// When hiding, forces macOS to process the policy change by calling
+/// `NSApp.hide()`. Without this, `setActivationPolicy(.accessory)` alone
+/// does not reliably remove the dock icon after the app has been presented
+/// as a Regular app.
 #[tauri::command]
 pub fn set_dock_visible(app: AppHandle, visible: bool) -> Result<(), AppError> {
     #[cfg(target_os = "macos")]
@@ -246,6 +251,18 @@ pub fn set_dock_visible(app: AppHandle, visible: bool) -> Result<(), AppError> {
         } else {
             ActivationPolicy::Accessory
         });
+        // Force macOS to update the dock by deactivating the app.
+        // set_activation_policy alone doesn't remove the dock icon
+        // after the app has already been presented as Regular.
+        if !visible {
+            unsafe {
+                use objc2::MainThreadMarker;
+                use objc2_app_kit::NSApplication;
+                let mtm = MainThreadMarker::new_unchecked();
+                let ns_app = NSApplication::sharedApplication(mtm);
+                ns_app.hide(None);
+            }
+        }
     }
     let _ = (app, visible);
     Ok(())

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -253,6 +253,15 @@ pub fn run() {
                         if hide_dock {
                             use tauri::ActivationPolicy;
                             let _ = app.set_activation_policy(ActivationPolicy::Accessory);
+                            // Force macOS to process the policy change.
+                            // Without this, the dock icon remains after
+                            // the app was already shown as Regular.
+                            unsafe {
+                                use objc2::MainThreadMarker;
+                                use objc2_app_kit::NSApplication;
+                                let mtm = MainThreadMarker::new_unchecked();
+                                NSApplication::sharedApplication(mtm).hide(None);
+                            }
                         }
                     }
                 }

--- a/src/components/layout/WindowControls.vue
+++ b/src/components/layout/WindowControls.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 /** @fileoverview Custom window control buttons (minimize, maximize, close). */
 import { getCurrentWindow } from '@tauri-apps/api/window'
+import { invoke } from '@tauri-apps/api/core'
 import { NIcon } from 'naive-ui'
 import { RemoveOutline, CopyOutline, CloseOutline } from '@vicons/ionicons5'
 import { usePreferenceStore } from '@/stores/preference'
@@ -16,9 +17,12 @@ function toggleMaximize() {
   appWindow.toggleMaximize()
 }
 
-function close() {
+async function close() {
   if (preferenceStore.config.minimizeToTrayOnClose) {
-    appWindow.hide()
+    await appWindow.hide()
+    if (preferenceStore.config.hideDockOnMinimize) {
+      await invoke('set_dock_visible', { visible: false })
+    }
   } else {
     appWindow.close()
   }

--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -121,6 +121,10 @@ async function onExitDialogAfterLeave() {
     pendingTrayHide.value = false
     const appWindow = getCurrentWindow()
     await appWindow.hide()
+    if (preferenceStore.config.hideDockOnMinimize) {
+      const { invoke } = await import('@tauri-apps/api/core')
+      await invoke('set_dock_visible', { visible: false })
+    }
   }
 }
 
@@ -295,6 +299,10 @@ onMounted(async () => {
     // GNOME Activities overview ×, and WM-level close signals on Wayland.
     if (preferenceStore.config.minimizeToTrayOnClose) {
       await appWindow.hide()
+      if (preferenceStore.config.hideDockOnMinimize) {
+        const { invoke } = await import('@tauri-apps/api/core')
+        await invoke('set_dock_visible', { visible: false })
+      }
       return
     }
 


### PR DESCRIPTION
<!--
Before submitting, read docs/CONTRIBUTING.md — especially the Pull Request section.

PR title MUST follow Conventional Commits format.

  Good titles:
    fix(macos): resolve tray icon blurriness on Retina displays
    feat: add per-task speed limit control
    docs: update i18n translation guide
    refactor: extract tracker sync into composable

  Bad titles:
    fix bugs
    update code
    fix #123
    WIP
-->

  ## Description

  When `hideDockOnMinimize` is enabled alongside `minimizeToTrayOnClose`, the dock icon only hides on the first app launch. After the user
  shows the window via tray and closes it again, the dock icon remains visible permanently.

  Two root causes:
  1. Frontend window-hide paths (custom close button, `onCloseRequested`, exit dialog minimize button) call `appWindow.hide()` directly —
  the Rust `CloseRequested` handler never fires, so dock-hiding code is bypassed.
  2. `setActivationPolicy(.accessory)` is silently ignored by macOS after the app has already been presented as a Regular app — the process
   must be deactivated first via `NSApp.hide()`.

  Fix: add `NSApp.hide(None)` after setting Accessory policy (Rust side), and call `set_dock_visible(false)` from all three frontend hide
  paths.

  ## Type of change

  - [x] Bug fix (non-breaking change that fixes an issue)
  - [ ] New feature (**must** be discussed and approved in an issue first)
  - [ ] Refactor (no functional change)
  - [ ] Documentation / i18n
  - [ ] CI / build configuration

  ## How has this been tested?

  - `cargo check --target aarch64-apple-darwin` — compiles cleanly
  - `cargo test` — 15/15 passed
  - `cargo clippy` — no new warnings (5 pre-existing)
  - `npx vue-tsc --noEmit` — zero errors
  - `pnpm test` — 710/710 passed
  - `pnpm format:check` — all files clean
  - Manual verification needed: enable both settings → close → dock icon hides → tray show → close again → dock icon hides again

  ## AI usage disclosure

  - [ ] No AI tools were used
  - [ ] AI tools assisted with drafting, refactoring, or boilerplate (I reviewed and understand every line)
  - [x] Substantial portions were AI-generated (I reviewed, tested, and can explain every change)

  If AI was used, specify the tool: Claude

  ## Checklist

  ### Required — PR will not be reviewed without these

  - [x] I have read [CONTRIBUTING.md](../docs/CONTRIBUTING.md)
  - [x] PR changes **fewer than 300 lines** of code (excluding tests and generated files) — 44 lines
  - [x] PR touches **fewer than 10 files** — 6 files
  - [x] PR addresses **one concern only** — no mixed features, config tweaks, or unrelated fixes
  - [x] All commands pass locally:
    pnpm format:check
    npx vue-tsc --noEmit
    pnpm test
    cd src-tauri && cargo test
  - [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format

  ### If applicable

  - [ ] New feature was discussed and approved in an issue before implementation
  - [ ] Tests written **before** implementation (TDD: red → green → refactor)
  - [ ] i18n keys updated in **all 26 locales** via batch Python script (see AGENTS.md §D)
  - [ ] New config key follows the full checklist in AGENTS.md §C
  - [ ] Rust changes compile with `cargo clippy` (zero warnings)

  ## Release notes

  Fixed macOS dock icon not re-hiding after showing and closing the window via tray.