### PR TITLE
feat: support magnet link without prefix

### DIFF
--- a/src/shared/utils/__tests__/batchHelpers.test.ts
+++ b/src/shared/utils/__tests__/batchHelpers.test.ts
@@ -7,11 +7,17 @@ describe('normalizeUriLines', () => {
       normalizeUriLines(`
         https://a.example/file
         magnet:?xt=urn:btih:abc
+        d8988e034cb5de79d319242e3365bf30a7741a6e
 
         https://a.example/file
         thunder://foo
       `),
-    ).toEqual(['https://a.example/file', 'magnet:?xt=urn:btih:abc', 'thunder://foo'])
+    ).toEqual([
+      'https://a.example/file',
+      'magnet:?xt=urn:btih:abc',
+      'magnet:?xt=urn:btih:d8988e034cb5de79d319242e3365bf30a7741a6e',
+      'thunder://foo',
+    ])
   })
 
   it('handles multiline payload text exactly like a textarea source', () => {

--- a/src/shared/utils/batchHelpers.ts
+++ b/src/shared/utils/batchHelpers.ts
@@ -60,11 +60,16 @@ export function resetBatchIdCounter(): void {
  * Split, trim, remove blanks, and deduplicate URI lines by first occurrence.
  * Handles multiline payloads — each line is treated as an independent URI.
  */
+const magnetHashRegex = /^[0-9a-fA-F]{40}$/
+
 export function normalizeUriLines(text: string): string[] {
   const seen = new Set<string>()
   const result: string[] = []
   for (const raw of text.split('\n')) {
-    const line = raw.trim()
+    let line = raw.trim()
+    if (magnetHashRegex.test(line)) {
+      line = `magnet:?xt=urn:btih:${line}`
+    }
     if (line && !seen.has(line)) {
       seen.add(line)
       result.push(line)

--- a/src/shared/utils/resource.ts
+++ b/src/shared/utils/resource.ts
@@ -16,7 +16,7 @@ export const decodeThunderLink = (url = ''): string => {
 
 export const splitTaskLinks = (links = ''): string[] => {
   const temp = compact(splitTextRows(links))
-  return temp.map((item) => decodeThunderLink(item))
+  return temp.map((item: string) => decodeThunderLink(item))
 }
 
 /**
@@ -41,7 +41,8 @@ export const detectResource = (content: string): boolean => {
 
   if (lines.length === 0) return false
 
-  return lines.every((line) => RESOURCE_TAGS.some((tag) => line.startsWith(tag)))
+  const magnetHashRegex = /^[0-9a-fA-F]{40}$/
+  return lines.every((line) => RESOURCE_TAGS.some((tag) => line.startsWith(tag)) || magnetHashRegex.test(line))
 }
 
 export const needCheckCopyright = (links = ''): boolean => {


### PR DESCRIPTION
## Description

Support magnet link without `magnet:?xt=urn:btih:` prefix

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (**must** be discussed and approved in an issue first)
- [ ] Refactor (no functional change)
- [ ] Documentation / i18n
- [ ] CI / build configuration

## How has this been tested?

Test added

## AI usage disclosure

- [ ] No AI tools were used
- [ ] AI tools assisted with drafting, refactoring, or boilerplate (I reviewed and understand every line)
- [x] Substantial portions were AI-generated (I reviewed, tested, and can explain every change)

If AI was used, specify the tool: Antigravity

## Checklist

### Required — PR will not be reviewed without these

- [x] I have read [CONTRIBUTING.md](../docs/CONTRIBUTING.md)
- [x] PR changes **fewer than 300 lines** of code (excluding tests and generated files)
- [x] PR touches **fewer than 10 files**
- [x] PR addresses **one concern only** — no mixed features, config tweaks, or unrelated fixes
- [x] All commands pass locally:
  ```
  pnpm format:check
  npx vue-tsc --noEmit
  pnpm test
  cd src-tauri && cargo test
  ```
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format

### If applicable

- [ ] New feature was discussed and approved in an issue before implementation
- [ ] Tests written **before** implementation (TDD: red → green → refactor)
- [ ] i18n keys updated in **all 26 locales** via batch Python script (see AGENTS.md §D)
- [ ] New config key follows the full checklist in AGENTS.md §C
- [ ] Rust changes compile with `cargo clippy` (zero warnings)

## Release notes

Notes: 

feat: Support magnet link without `magnet:?xt=urn:btih:` prefix