### PR TITLE
feat: add more architectures support

### DIFF
--- a/src/composables/__tests__/usePlatform.test.ts
+++ b/src/composables/__tests__/usePlatform.test.ts
@@ -117,11 +117,32 @@ describe('usePlatform', () => {
       expect(archLabel('x86_64')).toBe('x64')
     })
 
-    it('returns raw value for unknown architectures', async () => {
+    it('returns label for loongarch64', async () => {
       mockPlatform.mockReturnValue('linux')
       const mod = await import('../usePlatform')
       const { archLabel } = mod.usePlatform()
-      expect(archLabel('riscv64')).toBe('riscv64')
+      expect(archLabel('loongarch64')).toBe('LoongArch64')
+    })
+
+    it('returns label for mips64', async () => {
+      mockPlatform.mockReturnValue('linux')
+      const mod = await import('../usePlatform')
+      const { archLabel } = mod.usePlatform()
+      expect(archLabel('mips64')).toBe('MIPS64el')
+    })
+
+    it('returns label for powerpc64', async () => {
+      mockPlatform.mockReturnValue('linux')
+      const mod = await import('../usePlatform')
+      const { archLabel } = mod.usePlatform()
+      expect(archLabel('powerpc64')).toBe('PowerPC64el')
+    })
+
+    it('returns label for riscv64', async () => {
+      mockPlatform.mockReturnValue('linux')
+      const mod = await import('../usePlatform')
+      const { archLabel } = mod.usePlatform()
+      expect(archLabel('riscv64')).toBe('RISC-V64')
     })
   })
 

--- a/src/composables/usePlatform.ts
+++ b/src/composables/usePlatform.ts
@@ -48,6 +48,10 @@ const ARCH_LABELS: Record<string, string> = {
   aarch64: 'ARM64',
   x86_64: 'x64',
   x86: 'x86',
+  loongarch64: 'LoongArch64',
+  mips64: 'MIPS64el',
+  powerpc64: 'PowerPC64el',
+  riscv64: 'RISC-V64',
 }
 
 /**

--- a/src/shared/__tests__/sidecarBinaries.test.ts
+++ b/src/shared/__tests__/sidecarBinaries.test.ts
@@ -33,6 +33,10 @@ const EXPECTED_TARGETS = [
   // Linux
   'x86_64-unknown-linux-gnu',
   'aarch64-unknown-linux-gnu',
+  'loongarch64-unknown-linux-gnu',
+  'mips64el-unknown-linux-gnu',
+  'powerpc64le-unknown-linux-gnu',
+  'riscv64gc-unknown-linux-gnu',
 ] as const
 
 /** Minimum valid sidecar size in bytes (1 MB). Anything smaller is likely corrupt. */
@@ -128,6 +132,18 @@ describe('sidecar binaries', () => {
         } else if (target.includes('aarch64')) {
           // EM_AARCH64 = 183
           expect(machine).toBe(183)
+        } else if (target.includes('loongarch64')) {
+          // EM_LOONGARCH = 258
+          expect(machine).toBe(258)
+        } else if (target.includes('mips64el')) {
+          // EM_MIPS = 8 (MIPS64 little-endian)
+          expect(machine).toBe(8)
+        } else if (target.includes('powerpc64')) {
+          // EM_PPC64 = 21
+          expect(machine).toBe(21)
+        } else if (target.includes('riscv64')) {
+          // EM_RISCV = 243
+          expect(machine).toBe(243)
         }
       })
     }


### PR DESCRIPTION
## Description

适配更多的架构，增加了loongarch64，mips64el，powerpc64le，riscv64

## Type of change

<!-- Check the one that applies. -->

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (**must** be discussed and approved in an issue first)
- [ ] Refactor (no functional change)
- [ ] Documentation / i18n
- [ ] CI / build configuration

## How has this been tested?

<img width="1280" height="467" alt="图片" src="https://github.com/user-attachments/assets/e79f44b1-6b77-4ffb-86de-40f7e9784e5d" />

## AI usage disclosure

<!-- Check the one that applies. Honest disclosure is expected — misleading answers will result in PR closure. -->

- [ ] No AI tools were used
- [x] AI tools assisted with drafting, refactoring, or boilerplate (I reviewed and understand every line)
- [ ] Substantial portions were AI-generated (I reviewed, tested, and can explain every change)
AI对架构名的匹配并不太正确

If AI was used, specify the tool:  MiniMax M2.7

## Checklist

### Required — PR will not be reviewed without these

- [x] I have read [CONTRIBUTING.md](../docs/CONTRIBUTING.md)
- [x] PR changes **fewer than 300 lines** of code (excluding tests and generated files)
- [x] PR touches **fewer than 10 files**
- [x] PR addresses **one concern only** — no mixed features, config tweaks, or unrelated fixes
- [ ] All commands pass locally:
  ```
  pnpm format:check
  npx vue-tsc --noEmit
  pnpm test 
  cd src-tauri && cargo test
  ```
ci暂时未修改，pnpm test命令不可通过
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format

### If applicable

- [ ] New feature was discussed and approved in an issue before implementation
- [x] Tests written **before** implementation (TDD: red → green → refactor)
- [x] i18n keys updated in **all 26 locales** via batch Python script (see AGENTS.md §D)
- [x] New config key follows the full checklist in AGENTS.md §C
- [x] Rust changes compile with `cargo clippy` (zero warnings)

## Release notes

<!-- One-line description for end users, or "none" if not user-facing. -->

Notes: 
信创用户需要对新架构的支持