### PR TITLE
test: fix Windows quality checks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -422,11 +422,11 @@ fn reveal_in_explorer(path: &str) -> Result<(), AppError> {
     // `\\?\UNC\server\share\file` → `\\server\share\file`
     // This is the fix for GitHub issue #3304.
     let path_str = canonical.to_string_lossy();
-    let fixed: PathBuf = if path_str.starts_with(r"\\?\UNC\") {
-        PathBuf::from(format!(r"\\{}", &path_str[r"\\?\UNC\".len()..]))
-    } else if path_str.starts_with(r"\\?\") {
+    let fixed: PathBuf = if let Some(stripped) = path_str.strip_prefix(r"\\?\UNC\") {
+        PathBuf::from(format!(r"\\{stripped}"))
+    } else if let Some(stripped) = path_str.strip_prefix(r"\\?\") {
         // Shouldn't happen (dunce handles this), but defensive
-        PathBuf::from(&path_str[r"\\?\".len()..])
+        PathBuf::from(stripped)
     } else {
         canonical.clone()
     };
@@ -688,6 +688,18 @@ pub fn is_dmabuf_renderer_disabled() -> bool {
 mod tests {
     use super::*;
 
+    fn fs_source() -> String {
+        include_str!("fs.rs").replace("\r\n", "\n")
+    }
+
+    fn native_expected_path(path: &str) -> String {
+        if cfg!(windows) {
+            path.replace('/', "\\")
+        } else {
+            path.to_string()
+        }
+    }
+
     // ── check_path_exists ──────────────────────────────────────────────
 
     #[test]
@@ -755,15 +767,21 @@ mod tests {
     // ── normalize_path ─────────────────────────────────────────────────
 
     #[test]
-    fn normalize_path_preserves_simple_unix_path() {
+    fn normalize_path_uses_native_separators_for_simple_path() {
         let result = normalize_path("/home/user/downloads/file.txt");
-        assert_eq!(result, "/home/user/downloads/file.txt");
+        assert_eq!(
+            result,
+            native_expected_path("/home/user/downloads/file.txt")
+        );
     }
 
     #[test]
-    fn normalize_path_preserves_path_with_spaces() {
+    fn normalize_path_uses_native_separators_for_path_with_spaces() {
         let result = normalize_path("/home/user/my downloads/file name.txt");
-        assert_eq!(result, "/home/user/my downloads/file name.txt");
+        assert_eq!(
+            result,
+            native_expected_path("/home/user/my downloads/file name.txt")
+        );
     }
 
     #[test]
@@ -803,10 +821,9 @@ mod tests {
     }
 
     #[test]
-    fn normalize_path_handles_forward_slash_only() {
-        // Pure forward-slash paths (cross-platform compatible)
+    fn normalize_path_handles_forward_slash_only_with_native_separators() {
         let result = normalize_path("/var/log/app.log");
-        assert_eq!(result, "/var/log/app.log");
+        assert_eq!(result, native_expected_path("/var/log/app.log"));
     }
 
     // ── show_item_in_dir structural tests ──────────────────────────────
@@ -814,7 +831,7 @@ mod tests {
     /// Verifies show_item_in_dir calls normalize_path then reveal_in_explorer.
     #[test]
     fn show_item_in_dir_calls_normalize_then_reveal() {
-        let source = include_str!("fs.rs");
+        let source = fs_source();
         let fn_start = source
             .find("pub fn show_item_in_dir")
             .expect("show_item_in_dir function must exist");
@@ -834,7 +851,7 @@ mod tests {
     /// Verifies Windows cfg-gate exists and bypasses tauri_plugin_opener.
     #[test]
     fn reveal_in_explorer_has_windows_cfg_gate() {
-        let source = include_str!("fs.rs");
+        let source = fs_source();
         // Must have #[cfg(windows)] fn reveal_in_explorer
         assert!(
             source.contains("#[cfg(windows)]\nfn reveal_in_explorer"),
@@ -850,7 +867,7 @@ mod tests {
     /// Verifies the Windows implementation uses ILCreateFromPathW (not plugin).
     #[test]
     fn windows_reveal_uses_shell_api() {
-        let source = include_str!("fs.rs");
+        let source = fs_source();
         let cfg_start = source
             .find("#[cfg(windows)]\nfn reveal_in_explorer")
             .expect("Windows reveal_in_explorer must exist");
@@ -868,13 +885,13 @@ mod tests {
     /// Verifies the Windows implementation strips \\?\UNC\ prefix (issue #3304 fix).
     #[test]
     fn windows_reveal_strips_unc_prefix() {
-        let source = include_str!("fs.rs");
+        let source = fs_source();
         let cfg_start = source
             .find("#[cfg(windows)]\nfn reveal_in_explorer")
             .expect("Windows reveal_in_explorer must exist");
         let fn_body = &source[cfg_start..cfg_start + 2500];
         assert!(
-            fn_body.contains(r#"starts_with(r"\\?\UNC\")"#),
+            fn_body.contains(r#"strip_prefix(r"\\?\UNC\")"#),
             "Windows reveal must check for \\\\?\\UNC\\ prefix"
         );
     }
@@ -882,7 +899,7 @@ mod tests {
     /// Verifies the Windows implementation has an Electron-style ShellExecuteExW fallback.
     #[test]
     fn windows_reveal_has_shell_execute_fallback() {
-        let source = include_str!("fs.rs");
+        let source = fs_source();
         let cfg_start = source
             .find("#[cfg(windows)]\nfn reveal_in_explorer")
             .expect("Windows reveal_in_explorer must exist");
@@ -900,7 +917,7 @@ mod tests {
     /// Verifies non-Windows fallback uses tauri_plugin_opener.
     #[test]
     fn non_windows_reveal_uses_plugin_opener() {
-        let source = include_str!("fs.rs");
+        let source = fs_source();
         let cfg_start = source
             .find("#[cfg(not(windows))]\nfn reveal_in_explorer")
             .expect("non-Windows reveal_in_explorer must exist");
@@ -918,7 +935,7 @@ mod tests {
     /// is unsupported. See: https://github.com/rust-lang/rust/issues/99608
     #[test]
     fn windows_reveal_canonicalize_is_best_effort() {
-        let source = include_str!("fs.rs");
+        let source = fs_source();
         let cfg_start = source
             .find("#[cfg(windows)]\nfn reveal_in_explorer")
             .expect("Windows reveal_in_explorer must exist");
@@ -946,7 +963,7 @@ mod tests {
     /// Verifies canonicalize fallback logs a debug message for diagnostics.
     #[test]
     fn windows_reveal_canonicalize_fallback_logs_debug() {
-        let source = include_str!("fs.rs");
+        let source = fs_source();
         let cfg_start = source
             .find("#[cfg(windows)]\nfn reveal_in_explorer")
             .expect("Windows reveal_in_explorer must exist");
@@ -965,7 +982,7 @@ mod tests {
     /// Verifies canonicalize fallback creates PathBuf from the input path.
     #[test]
     fn windows_reveal_canonicalize_fallback_uses_input_path() {
-        let source = include_str!("fs.rs");
+        let source = fs_source();
         let cfg_start = source
             .find("#[cfg(windows)]\nfn reveal_in_explorer")
             .expect("Windows reveal_in_explorer must exist");
@@ -984,7 +1001,7 @@ mod tests {
     /// ShellExecuteExW requires Win32_System_Registry feature; ShellExecuteW does not.
     #[test]
     fn shell_execute_open_uses_shell_execute_w() {
-        let source = include_str!("fs.rs");
+        let source = fs_source();
         // Verify the import line exists in the actual function (not test code).
         // The function imports "Shell::ShellExecuteW;" (note the semicolon — not Ex variant).
         assert!(
@@ -996,7 +1013,7 @@ mod tests {
     /// Verifies the to_wide helper function exists with cfg(windows).
     #[test]
     fn to_wide_helper_exists() {
-        let source = include_str!("fs.rs");
+        let source = fs_source();
         // Check the cfg gate + function signature + utf16 encoding all exist
         assert!(
             source.contains("#[cfg(windows)]\nfn to_wide("),
@@ -1011,7 +1028,7 @@ mod tests {
     /// Verifies show_item_in_dir includes debug logging for traceability.
     #[test]
     fn show_item_in_dir_has_debug_logging() {
-        let source = include_str!("fs.rs");
+        let source = fs_source();
         // Search within the function body (between pub fn and next fn/doc comment)
         let fn_start = source
             .find("pub fn show_item_in_dir")
@@ -1031,7 +1048,7 @@ mod tests {
     /// Verifies Windows reveal_in_explorer initializes COM before Shell API calls.
     #[test]
     fn windows_reveal_initializes_com() {
-        let source = include_str!("fs.rs");
+        let source = fs_source();
         let cfg_start = source
             .find("#[cfg(windows)]\nfn reveal_in_explorer")
             .expect("Windows reveal_in_explorer must exist");
@@ -1051,7 +1068,7 @@ mod tests {
     /// Verifies open_path_normalized calls normalize_path before open_path.
     #[test]
     fn open_path_normalized_calls_normalize_path() {
-        let source = include_str!("fs.rs");
+        let source = fs_source();
         let fn_start = source
             .find("pub fn open_path_normalized")
             .expect("open_path_normalized function must exist");
@@ -1073,7 +1090,7 @@ mod tests {
     /// Verifies normalize_path uses components().collect() for separator normalization.
     #[test]
     fn normalize_path_uses_components_collect() {
-        let source = include_str!("fs.rs");
+        let source = fs_source();
         let fn_start = source
             .find("pub(crate) fn normalize_path")
             .expect("normalize_path function must exist");
@@ -1092,7 +1109,7 @@ mod tests {
     /// Verifies normalize_path uses dunce::simplified for prefix stripping.
     #[test]
     fn normalize_path_uses_dunce() {
-        let source = include_str!("fs.rs");
+        let source = fs_source();
         let fn_start = source
             .find("pub(crate) fn normalize_path")
             .expect("normalize_path function must exist");
@@ -1111,7 +1128,7 @@ mod tests {
     /// Verifies normalize_path includes debug logging.
     #[test]
     fn normalize_path_has_debug_logging() {
-        let source = include_str!("fs.rs");
+        let source = fs_source();
         let fn_start = source
             .find("pub(crate) fn normalize_path")
             .expect("normalize_path function must exist");

--- a/src-tauri/src/engine/lifecycle.rs
+++ b/src-tauri/src/engine/lifecycle.rs
@@ -77,7 +77,7 @@ fn kill_process_by_pid(pid: u32) -> Result<(), String> {
         if status.success() {
             return Ok(());
         }
-        return Err(format!("taskkill failed for PID {pid}: {status}"));
+        Err(format!("taskkill failed for PID {pid}: {status}"))
     }
 
     #[cfg(not(windows))]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -392,7 +392,7 @@ fn setup_app(app: &mut tauri::App) -> Result<(), Box<dyn std::error::Error>> {
         };
         if let Some(w) = app.get_webview_window("main") {
             if let Ok(hwnd_handle) = w.hwnd() {
-                let hwnd = hwnd_handle.0 as *mut std::ffi::c_void;
+                let hwnd = hwnd_handle.0;
                 // DWMWCP_ROUND = 2: force DWM native rounded corners
                 let preference: u32 = 2;
                 unsafe {

--- a/src-tauri/src/services/power.rs
+++ b/src-tauri/src/services/power.rs
@@ -8,7 +8,9 @@
 use crate::error::AppError;
 
 const DOWNLOAD_REASON: &str = "Active downloads in progress";
+#[cfg(not(target_os = "windows"))]
 const APP_NAME: &str = "Motrix Next";
+#[cfg(not(target_os = "windows"))]
 const APP_REVERSE_DOMAIN: &str = "com.motrix.next";
 
 pub struct PowerGuard {

--- a/src-tauri/src/tray.rs
+++ b/src-tauri/src/tray.rs
@@ -2,9 +2,12 @@ use std::collections::HashMap;
 use std::sync::Mutex;
 use tauri::{
     menu::{Menu, MenuItem, PredefinedMenuItem},
-    tray::{MouseButton, MouseButtonState, TrayIcon, TrayIconBuilder, TrayIconEvent},
+    tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
     AppHandle, Emitter, Manager, WebviewUrl, WebviewWindowBuilder,
 };
+
+#[cfg(not(target_os = "windows"))]
+use tauri::tray::TrayIcon;
 
 /// Embedded tray icon bytes.
 ///
@@ -40,6 +43,7 @@ pub fn tray_icon_image() -> tauri::image::Image<'static> {
 /// monochrome mask correctly on light, dark, and highlighted menu bar states.
 /// Any path that re-sets the icon must restore that flag immediately afterward,
 /// otherwise AppKit treats the bitmap as a normal white image.
+#[cfg(not(target_os = "windows"))]
 pub fn refresh_tray_icon(tray: &TrayIcon<tauri::Wry>) -> tauri::Result<()> {
     let icon = tray_icon_image();
     tray.set_icon(Some(icon))?;

--- a/src/components/preference/__tests__/UpdateDialogStructure.test.ts
+++ b/src/components/preference/__tests__/UpdateDialogStructure.test.ts
@@ -6,10 +6,10 @@
  * runtime while still enforcing code-quality invariants.
  */
 import { describe, it, expect } from 'vitest'
-import { readFileSync } from 'fs'
-import { resolve } from 'path'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 
-const SOURCE = readFileSync(resolve(__dirname, '../UpdateDialog.vue'), 'utf-8')
+const SOURCE = readFileSync(resolve(process.cwd(), 'src/components/preference/UpdateDialog.vue'), 'utf-8')
 
 // ── handleInstallAndRelaunch error handling ─────────────────────────
 

--- a/src/shared/__tests__/tauriPluginSync.test.ts
+++ b/src/shared/__tests__/tauriPluginSync.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest'
-import { readFileSync } from 'fs'
-import { resolve } from 'path'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 
 /**
  * Tauri Plugin Version Sync Tests
@@ -18,7 +18,7 @@ import { resolve } from 'path'
  * in bump-version.sh prevents this, but this test acts as a safety net.
  */
 
-const PROJECT_ROOT = resolve(__dirname, '..', '..', '..')
+const PROJECT_ROOT = process.cwd()
 const CARGO_LOCK = resolve(PROJECT_ROOT, 'src-tauri', 'Cargo.lock')
 const PNPM_LOCK = resolve(PROJECT_ROOT, 'pnpm-lock.yaml')
 
@@ -34,7 +34,7 @@ const PNPM_LOCK = resolve(PROJECT_ROOT, 'pnpm-lock.yaml')
  */
 function parseCargoLockPlugins(content: string): Map<string, string> {
   const plugins = new Map<string, string>()
-  const pattern = /name = "tauri-plugin-([^"]+)"\nversion = "([^"]+)"/g
+  const pattern = /name = "tauri-plugin-([^"]+)"\r?\nversion = "([^"]+)"/g
   let match: RegExpExecArray | null
 
   while ((match = pattern.exec(content)) !== null) {

--- a/src/shared/__tests__/upnpShutdownBehavior.test.ts
+++ b/src/shared/__tests__/upnpShutdownBehavior.test.ts
@@ -1,15 +1,18 @@
 import { describe, it, expect } from 'vitest'
-import { readFileSync } from 'fs'
-import { resolve } from 'path'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
 
-const LIB_SOURCE = readFileSync(resolve(__dirname, '../../../src-tauri/src/lib.rs'), 'utf-8')
+const LIB_SOURCE = readFileSync(resolve(process.cwd(), 'src-tauri/src/lib.rs'), 'utf-8')
 
 describe('UPnP shutdown behavior', () => {
   it('wraps stop_mapping in a timeout on app exit', () => {
     const exitIdx = LIB_SOURCE.indexOf('tauri::RunEvent::Exit =>')
     expect(exitIdx).toBeGreaterThanOrEqual(0)
-    const snippet = LIB_SOURCE.slice(exitIdx, exitIdx + 3200)
-    expect(snippet).toContain('timeout(')
-    expect(snippet).toContain('upnp::stop_mapping')
+    const exitSnippet = LIB_SOURCE.slice(exitIdx)
+    const stopMappingIdx = exitSnippet.indexOf('upnp::stop_mapping')
+    expect(stopMappingIdx).toBeGreaterThanOrEqual(0)
+
+    const upnpCleanupSnippet = exitSnippet.slice(Math.max(0, stopMappingIdx - 240), stopMappingIdx + 240)
+    expect(upnpCleanupSnippet).toContain('tokio::time::timeout(')
   })
 })


### PR DESCRIPTION
## Description

Fix Windows-local quality checks that failed even though the project logic was unchanged:

- make source-file structural tests tolerate Windows line endings and native path separators
- add a repository line-ending rule so checked source stays consistent across platforms
- clean up small Windows-only lint warnings so strict Rust checks pass locally

Manual review note: 人工复核过. I reviewed every changed line before submitting.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (**must** be discussed and approved in an issue first)
- [ ] Refactor (no functional change)
- [ ] Documentation / i18n
- [x] CI / build configuration

## How has this been tested?

- [x] `pnpm format:check`
- [x] `pnpm lint` (passes with existing warnings only)
- [x] `npx vue-tsc --noEmit`
- [x] `pnpm test` (2667 tests passed)
- [x] `npx vite build` (passes with existing build warnings)
- [x] `cd src-tauri && cargo fmt -- --check`
- [x] `cd src-tauri && cargo clippy --all-targets -- -D warnings`
- [x] `cd src-tauri && cargo check --all-targets`
- [x] `cd src-tauri && cargo test --all-targets` (513 tests passed)

## AI usage disclosure

- [ ] No AI tools were used
- [x] AI tools assisted with drafting, refactoring, or boilerplate (I reviewed and understand every line)
- [ ] Substantial portions were AI-generated (I reviewed, tested, and can explain every change)

If AI was used, specify the tool: ChatGPT

## Checklist

### Required - PR will not be reviewed without these

- [x] I have read [CONTRIBUTING.md](../docs/CONTRIBUTING.md)
- [x] PR changes **fewer than 300 lines** of code (excluding tests and generated files)
- [x] PR touches **fewer than 10 files**
- [x] PR addresses **one concern only** - no mixed features, config tweaks, or unrelated fixes
- [x] All commands pass locally:
  ```
  pnpm format:check
  npx vue-tsc --noEmit
  pnpm test
  cd src-tauri && cargo test
  ```
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format

### If applicable

- [ ] New feature was discussed and approved in an issue before implementation
- [ ] Tests written **before** implementation (TDD: red -> green -> refactor)
- [ ] i18n keys updated in **all 26 locales** via batch Python script (see AGENTS.md Section D)
- [ ] New config key follows the full checklist in AGENTS.md Section C
- [x] Rust changes compile with `cargo clippy` (zero warnings)

## Release notes

none