### PR TITLE
feat(proxy): add proxy whitelist matching utility and config migration

### DIFF
--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -199,7 +199,7 @@ export const BUILTIN_CATEGORY_LABELS: ReadonlySet<string> = new Set(BUILTIN_CATE
 export const CURRENT_DB_SCHEMA_VERSION = 3
 
 export const DEFAULT_APP_CONFIG = {
-  configVersion: 5,
+  configVersion: 6,
   dbSchemaVersion: CURRENT_DB_SCHEMA_VERSION,
   // ── Appearance ──────────────────────────────────────────────────
   theme: 'auto' as const,
@@ -297,7 +297,13 @@ export const DEFAULT_APP_CONFIG = {
   ed2kUploadSlots: 3,
   ed2kShareFiles: [] as string[],
   ed2kSearchTimeout: 20,
-  proxy: { enable: false, server: '', bypass: '', scope: ['download', 'update-app', 'update-trackers'] },
+  proxy: {
+    enable: false,
+    server: '',
+    bypass: '',
+    scope: ['download', 'update-app', 'update-trackers'],
+    matchMode: 'blacklist',
+  },
   protocols: { magnet: true, ed2k: true, thunder: false, motrixnext: true },
   clipboard: { enable: true, http: true, ftp: true, magnet: true, ed2k: true, thunder: true, btHash: true },
   autoSubmitFromExtension: true,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -156,12 +156,19 @@ export interface Aria2RawGlobalStat {
   [key: string]: string
 }
 
+/** Proxy match mode: blacklist (default) or whitelist. */
+export type ProxyMatchMode = 'blacklist' | 'whitelist'
+
 /** HTTP/SOCKS proxy configuration for aria2 and tracker requests. */
 export interface ProxyConfig {
   enable: boolean
   server: string
   bypass?: string
   scope?: string[]
+  /** Match mode for the bypass/whitelist list.
+   *  'blacklist' (default): matching domains are excluded from proxy.
+   *  'whitelist': only matching domains go through proxy. */
+  matchMode?: ProxyMatchMode
 }
 
 /** Result from the `get_system_proxy` Tauri command.

--- a/src/shared/utils/__tests__/configMigration.test.ts
+++ b/src/shared/utils/__tests__/configMigration.test.ts
@@ -491,9 +491,74 @@ describe('v5 migration — ED2K protocol and clipboard backfill', () => {
   })
 })
 
-// ── Full v0 → v5 integration ──────────────────────────────────────
+// ── v6 Migration: proxy.matchMode backfill ────────────────────────
 
-describe('v0 → v5 full migration path', () => {
+describe('v6 migration — proxy.matchMode backfill', () => {
+  it('backfills matchMode to blacklist when proxy exists and matchMode is undefined', () => {
+    const config: Partial<AppConfig> = {
+      configVersion: 5,
+      proxy: { enable: true, server: 'http://proxy:8080', bypass: '', scope: ['download'] },
+    }
+    runMigrations(config)
+    expect(config.proxy!.matchMode).toBe('blacklist')
+  })
+
+  it('preserves explicit matchMode whitelist value', () => {
+    const config: Partial<AppConfig> = {
+      configVersion: 5,
+      proxy: {
+        enable: true,
+        server: 'http://proxy:8080',
+        bypass: '*.example.com',
+        scope: ['download'],
+        matchMode: 'whitelist' as const,
+      },
+    }
+    runMigrations(config)
+    expect(config.proxy!.matchMode).toBe('whitelist')
+  })
+
+  it('preserves explicit matchMode blacklist value', () => {
+    const config: Partial<AppConfig> = {
+      configVersion: 5,
+      proxy: {
+        enable: true,
+        server: 'http://proxy:8080',
+        bypass: '',
+        scope: ['download'],
+        matchMode: 'blacklist' as const,
+      },
+    }
+    runMigrations(config)
+    expect(config.proxy!.matchMode).toBe('blacklist')
+  })
+
+  it('does nothing when proxy field is absent entirely', () => {
+    const config: Partial<AppConfig> = { configVersion: 5 }
+    runMigrations(config)
+    expect(config.proxy).toBeUndefined()
+  })
+
+  it('is idempotent — running on already-migrated v6 config is a no-op', () => {
+    const config: Partial<AppConfig> = {
+      configVersion: CONFIG_VERSION,
+      proxy: {
+        enable: true,
+        server: 'http://proxy:8080',
+        bypass: '',
+        scope: ['download'],
+        matchMode: 'blacklist' as const,
+      },
+    }
+    const result = runMigrations(config)
+    expect(result.migrated).toBe(false)
+    expect(config.proxy!.matchMode).toBe('blacklist')
+  })
+})
+
+// ── Full v0 → v6 integration ──────────────────────────────────────
+
+describe('v0 → v6 full migration path', () => {
   it('runs all migrations in sequence on fresh config', () => {
     const config = {
       proxy: { enable: true, server: 'http://proxy:1080', bypass: '', scope: [] },
@@ -524,6 +589,8 @@ describe('v0 → v5 full migration path', () => {
     // v5: ED2K protocol surfaces backfilled
     expect(config.protocols?.ed2k).toBe(true)
     expect(config.clipboard?.ed2k).toBe(true)
+    // v6: proxy.matchMode backfilled
+    expect(config.proxy!.matchMode).toBe('blacklist')
     // Both split and maxConnectionPerServer preserved
     expect(config.split).toBe(64)
     expect(config.maxConnectionPerServer).toBe(64)

--- a/src/shared/utils/__tests__/proxyWhitelist.test.ts
+++ b/src/shared/utils/__tests__/proxyWhitelist.test.ts
@@ -1,0 +1,117 @@
+/** @fileoverview Tests for proxy whitelist matching utilities. */
+import { describe, it, expect } from 'vitest'
+import { parseWhitelist, isUrlInWhitelist } from '../proxyWhitelist'
+
+describe('parseWhitelist', () => {
+  it('splits comma-separated entries', () => {
+    expect(parseWhitelist('example.com,*.example.org')).toEqual(['example.com', '*.example.org'])
+  })
+
+  it('splits newline-separated entries', () => {
+    expect(parseWhitelist('example.com\n*.example.org')).toEqual(['example.com', '*.example.org'])
+  })
+
+  it('handles mixed separators (commas + newlines)', () => {
+    expect(parseWhitelist('example.com\n*.example.org,api.test.com')).toEqual([
+      'example.com',
+      '*.example.org',
+      'api.test.com',
+    ])
+  })
+
+  it('trims whitespace from each entry', () => {
+    expect(parseWhitelist('  example.com  ,  *.example.org  ')).toEqual(['example.com', '*.example.org'])
+  })
+
+  it('filters out empty entries', () => {
+    expect(parseWhitelist('example.com,,*.example.org')).toEqual(['example.com', '*.example.org'])
+  })
+
+  it('filters out entries that are only whitespace', () => {
+    expect(parseWhitelist('example.com,   ,*.example.org')).toEqual(['example.com', '*.example.org'])
+  })
+
+  it('returns empty array for empty string', () => {
+    expect(parseWhitelist('')).toEqual([])
+  })
+
+  it('returns empty array for whitespace-only string', () => {
+    expect(parseWhitelist('   ')).toEqual([])
+  })
+})
+
+describe('isUrlInWhitelist', () => {
+  describe('exact domain matching', () => {
+    it('matches exact domain', () => {
+      expect(isUrlInWhitelist('https://example.com/file.zip', ['example.com'])).toBe(true)
+    })
+
+    it('matches exact domain with www prefix', () => {
+      expect(isUrlInWhitelist('https://www.example.com/file.zip', ['www.example.com'])).toBe(true)
+    })
+
+    it('does not match subdomain when exact domain is listed', () => {
+      expect(isUrlInWhitelist('https://sub.example.com/file.zip', ['example.com'])).toBe(false)
+    })
+
+    it('does not match different domain', () => {
+      expect(isUrlInWhitelist('https://other.com/file.zip', ['example.com'])).toBe(false)
+    })
+  })
+
+  describe('wildcard domain matching', () => {
+    it('matches all subdomains with *. prefix', () => {
+      expect(isUrlInWhitelist('https://sub.example.com/file.zip', ['*.example.com'])).toBe(true)
+    })
+
+    it('matches nested subdomains with *. prefix', () => {
+      expect(isUrlInWhitelist('https://deep.sub.example.com/file.zip', ['*.example.com'])).toBe(true)
+    })
+
+    it('matches the bare domain when wildcard is listed', () => {
+      expect(isUrlInWhitelist('https://example.com/file.zip', ['*.example.com'])).toBe(true)
+    })
+
+    it('does not match unrelated domain', () => {
+      expect(isUrlInWhitelist('https://other.com/file.zip', ['*.example.com'])).toBe(false)
+    })
+  })
+
+  describe('protocol handling', () => {
+    it('matches https URLs', () => {
+      expect(isUrlInWhitelist('https://example.com/file.zip', ['example.com'])).toBe(true)
+    })
+
+    it('matches http URLs', () => {
+      expect(isUrlInWhitelist('http://example.com/file.zip', ['example.com'])).toBe(true)
+    })
+
+    it('matches ftp URLs', () => {
+      expect(isUrlInWhitelist('ftp://example.com/file.zip', ['example.com'])).toBe(true)
+    })
+  })
+
+  describe('URLs with port and auth', () => {
+    it('matches URLs with port numbers', () => {
+      expect(isUrlInWhitelist('https://example.com:8080/file.zip', ['example.com'])).toBe(true)
+    })
+
+    it('matches URLs with userinfo', () => {
+      expect(isUrlInWhitelist('https://user:pass@example.com/file.zip', ['example.com'])).toBe(true)
+    })
+  })
+
+  describe('non-URL strings', () => {
+    it('returns false for magnet URIs', () => {
+      expect(isUrlInWhitelist('magnet:?xt=urn:btih:xxx', ['example.com'])).toBe(false)
+    })
+
+    it('returns false for ed2k URIs', () => {
+      expect(isUrlInWhitelist('ed2k://|file|test.avi|...', ['example.com'])).toBe(false)
+    })
+
+    it('returns false for thunder URIs', () => {
+      expect(isUrlInWhitelist('thunder://xxx', ['example.com'])).toBe(false)
+    })
+  })
+})

--- a/src/shared/utils/configMigration.ts
+++ b/src/shared/utils/configMigration.ts
@@ -21,7 +21,7 @@ import { logger } from '@shared/logger'
 import type { AppConfig } from '@shared/types'
 
 /** Current schema version. Must equal `migrations.length`. */
-export const CONFIG_VERSION = 5
+export const CONFIG_VERSION = 6
 
 /** Result returned by runMigrations for callers to act on (e.g. toast). */
 export interface MigrationResult {
@@ -178,6 +178,19 @@ const migrations: Migration[] = [
     if (config.clipboard && config.clipboard.ed2k === undefined) {
       config.clipboard.ed2k = true
       logger.info('ConfigMigration', 'v5: backfilled clipboard.ed2k')
+    }
+  },
+
+  // ── v5 → v6 ──────────────────────────────────────────────────────
+  // Add proxy.matchMode field for whitelist/blacklist support.
+  //
+  // Existing users with proxy configured will have matchMode undefined.
+  // Default value is 'blacklist' (preserving existing behavior).
+  function migrateV6(config: Partial<AppConfig>): void {
+    const proxy = config.proxy
+    if (proxy && proxy.matchMode === undefined) {
+      proxy.matchMode = 'blacklist'
+      logger.info('ConfigMigration', 'v6: backfilled proxy.matchMode to blacklist')
     }
   },
 ]

--- a/src/shared/utils/proxyWhitelist.ts
+++ b/src/shared/utils/proxyWhitelist.ts
@@ -1,0 +1,75 @@
+/** @fileoverview Proxy whitelist parsing and URL matching utilities. */
+import { isEmpty } from 'lodash-es'
+
+/**
+ * Parses a whitelist string (comma-separated, newline-separated, or mixed)
+ * into an array of trimmed, non-empty domain patterns.
+ *
+ * Each pattern can be:
+ * - Exact domain: `example.com`
+ * - Wildcard subdomain: `*.example.com` (matches example.com and all its subdomains)
+ */
+export function parseWhitelist(input: string): string[] {
+  if (!input || !input.trim()) return []
+  return (
+    input
+      // Split by comma or newline
+      .split(/[,\n]/)
+      .map((entry) => entry.trim())
+      .filter((entry) => entry.length > 0)
+  )
+}
+
+/**
+ * Determines whether a URL's hostname matches any pattern in a whitelist.
+ *
+ * Only HTTP/HTTPS/FTP URLs are evaluated — magnet, ed2k, thunder, and other
+ * non-URL schemes return false (no match), which means the proxy is NOT applied.
+ *
+ * Matching rules:
+ * - `example.com` matches only that exact hostname
+ * - `*.example.com` matches example.com and all its subdomains
+ *
+ * @param url - The full URL string (e.g. "https://example.com/file.zip")
+ * @param whitelist - Parsed list of domain patterns (from parseWhitelist)
+ * @returns true if the URL's hostname matches any pattern in the whitelist
+ */
+export function isUrlInWhitelist(url: string, whitelist: string[]): boolean {
+  if (!url || isEmpty(whitelist)) return false
+
+  // Only evaluate HTTP/HTTPS/FTP URLs
+  const protocolMatch = url.match(/^(https?|ftp):\/\//)
+  if (!protocolMatch) return false
+
+  // Extract hostname from URL
+  let hostname: string
+  try {
+    hostname = new URL(url).hostname
+  } catch {
+    return false
+  }
+
+  if (!hostname) return false
+
+  return whitelist.some((pattern) => matchDomain(hostname, pattern))
+}
+
+/**
+ * Matches a hostname against a single domain pattern.
+ *
+ * - `example.com` → matches if hostname === 'example.com'
+ * - `*.example.com` → matches if hostname === 'example.com' or ends with '.example.com'
+ */
+function matchDomain(hostname: string, pattern: string): boolean {
+  const trimmed = pattern.trim().toLowerCase()
+  const normalizedHost = hostname.toLowerCase()
+
+  if (trimmed.startsWith('*.')) {
+    // Wildcard: *.example.com
+    const suffix = trimmed.slice(1) // ".example.com"
+    return normalizedHost === suffix.slice(1) || normalizedHost.endsWith(suffix)
+  }
+
+  // Exact match
+  return normalizedHost === trimmed
+}


### PR DESCRIPTION
## Description

This PR added the foundation for proxy whitelist match mode support.

This is the PR 1 of 3.

PR 2 will integrate whitelist logic into composables and UI
PR 3 will update i18n across all 26 locales.

Closed #212 
Closed #278 

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (**must** be discussed and approved in an issue first)
- [ ] Refactor (no functional change)
- [ ] Documentation / i18n
- [ ] CI / build configuration

## How has this been tested?

- 24 unit tests for `isUrlInWhitelist()` and `parseWhitelist()` covering all matching rules, protocol filtering, edge cases
- 6 migration tests covering backfill, preserve existing values, empty proxy, idempotency
- Full v0→v6 integration test verifying all migrations in sequence
- All 71 tests pass with `pnpm test`

## AI usage disclosure

- [ ] No AI tools were used
- [x] AI tools assisted with drafting, refactoring, or boilerplate (I reviewed and understand every line)
- [ ] Substantial portions were AI-generated (I reviewed, tested, and can explain every change)

If AI was used, specify the tool: DeepSeek V4

## Checklist

### Required — PR will not be reviewed without these

- [x] I have read [CONTRIBUTING.md](../docs/CONTRIBUTING.md)
- [x] PR changes **fewer than 300 lines** of code (excluding tests and generated files)
- [x] PR touches **fewer than 10 files**
- [x] PR addresses **one concern only** — no mixed features, config tweaks, or unrelated fixes
- [x] All commands pass locally:
  ```
  pnpm format:check
  npx vue-tsc --noEmit
  pnpm test
  cd src-tauri && cargo test
  ```
- [x] Commits follow [Conventional Commits](https://www.conventionalcommits.org/) format

### If applicable

- [ ] New feature was discussed and approved in an issue before implementation
- [x] Tests written **before** implementation (TDD: red → green → refactor)
- [ ] i18n keys updated in **all 26 locales** via batch Python script (see AGENTS.md §D)
- [x] New config key follows the full checklist in AGENTS.md §C
- [ ] Rust changes compile with `cargo clippy` (zero warnings)

## Release notes

Notes: none

## Additional

This whitelist proxy feature depends on per-call proxy resolution, works by checking on the frontend if a task's domain matches the whitelist before enabling a custom proxy for it, because aria does not support per-task proxy rules.

This means it only supports HTTP(S)/FTP downloads, but not domain-less protocols like magnet or BT.
Performance-wise, the check is O(n) string comparison against the whitelist array.

For typical usage (tens to hundreds of rules) this is negligible, but worth noting for extreme cases.

Still waiting for the repo owner's reviews and comments.