### PR TITLE
 fix(task): show insufficient disk space error before download starts

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1656,6 +1656,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3076,6 +3086,7 @@ dependencies = [
  "core-foundation 0.10.1",
  "dirs 6.0.0",
  "dunce",
+ "fs2",
  "igd-next",
  "keepawake",
  "log",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,6 +60,7 @@ content_disposition = "0.4"
 rfc2047-decoder = "1.1"
 strip-ansi-escapes = "0.2.1"
 tempfile = "3"
+fs2 = "0.4"
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.59", features = [

--- a/src-tauri/src/aria2/client.rs
+++ b/src-tauri/src/aria2/client.rs
@@ -27,13 +27,23 @@ pub struct Aria2Client {
 pub struct Aria2State(pub Arc<Aria2Client>);
 
 impl Aria2Client {
+    fn build_http_client() -> reqwest::Client {
+        match reqwest::Client::builder().no_proxy().build() {
+            Ok(client) => client,
+            Err(error) => {
+                log::warn!("aria2 client: failed to build no-proxy HTTP client: {error}");
+                reqwest::Client::new()
+            }
+        }
+    }
+
     /// Creates a new client with default credentials.
     ///
     /// The `reqwest::Client` is reused across all requests for connection
     /// pooling.  Credentials can be updated later via `update_credentials`.
     pub fn new(port: u16, secret: String) -> Self {
         Self {
-            http: reqwest::Client::new(),
+            http: Self::build_http_client(),
             port: RwLock::new(port),
             secret: RwLock::new(secret),
             request_id: AtomicU64::new(1),
@@ -449,8 +459,16 @@ mod tests {
 
     #[tokio::test]
     async fn call_returns_aria2_error_on_connection_refused() {
-        // Use a port where nothing is listening
-        let client = Aria2Client::new(19999, String::new());
+        // Reserve an ephemeral port and release it immediately so the test
+        // does not depend on a hard-coded port being unused in CI.
+        let listener = std::net::TcpListener::bind("127.0.0.1:0")
+            .expect("ephemeral TCP port should be available");
+        let port = listener
+            .local_addr()
+            .expect("listener should expose local addr")
+            .port();
+        drop(listener);
+        let client = Aria2Client::new(port, String::new());
         let result = client.save_session().await;
 
         assert!(result.is_err());

--- a/src-tauri/src/commands/fs.rs
+++ b/src-tauri/src/commands/fs.rs
@@ -1,9 +1,87 @@
 use crate::engine::{valid_aria2_log_level, DEFAULT_ARIA2_LOG_LEVEL};
 use crate::error::AppError;
+use serde::Serialize;
 use serde_json::Value;
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
 use tauri::AppHandle;
 use tauri::Manager;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExistingFileSize {
+    pub relative_path: String,
+    pub size_bytes: u64,
+}
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiskSpaceInfo {
+    pub path: String,
+    pub checked_path: String,
+    pub available_bytes: u64,
+    pub existing_file_sizes: Vec<ExistingFileSize>,
+}
+
+fn nearest_existing_path(path: &Path) -> Option<PathBuf> {
+    if path.exists() {
+        return Some(path.to_path_buf());
+    }
+    path.ancestors()
+        .find(|ancestor| ancestor.exists())
+        .map(Path::to_path_buf)
+}
+
+fn absolute_requested_path(path: &Path) -> PathBuf {
+    if path.is_absolute() {
+        return path.to_path_buf();
+    }
+    std::env::current_dir()
+        .map(|cwd| cwd.join(path))
+        .unwrap_or_else(|_| path.to_path_buf())
+}
+
+fn safe_relative_download_path(path: &str) -> Option<PathBuf> {
+    let requested = Path::new(path);
+    if requested.is_absolute() {
+        return None;
+    }
+
+    let mut safe_path = PathBuf::new();
+    for component in requested.components() {
+        match component {
+            Component::Normal(segment) => safe_path.push(segment),
+            Component::CurDir => {}
+            Component::ParentDir | Component::RootDir | Component::Prefix(_) => return None,
+        }
+    }
+
+    if safe_path.as_os_str().is_empty() {
+        None
+    } else {
+        Some(safe_path)
+    }
+}
+
+fn existing_file_sizes(
+    base_path: &Path,
+    relative_paths: Option<Vec<String>>,
+) -> Vec<ExistingFileSize> {
+    let Some(relative_paths) = relative_paths else {
+        return Vec::new();
+    };
+
+    relative_paths
+        .into_iter()
+        .filter_map(|relative_path| {
+            let safe_path = safe_relative_download_path(&relative_path)?;
+            let size_bytes = std::fs::metadata(base_path.join(safe_path)).ok()?.len();
+            Some(ExistingFileSize {
+                relative_path,
+                size_bytes,
+            })
+        })
+        .collect()
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ManagedLogFileKind {
@@ -502,6 +580,36 @@ mod export_tests {
             "notice"
         );
     }
+}
+
+/// Returns available disk space for the volume containing the requested path.
+///
+/// The download directory may not exist yet (aria2 can create it later), so the
+/// check walks up to the nearest existing ancestor before asking the OS for the
+/// free-space value. This keeps torrent preflight reliable for new subfolders
+/// while still reporting the user-requested path back to the frontend.
+#[tauri::command]
+pub fn get_available_disk_space(
+    path: String,
+    relative_paths: Option<Vec<String>>,
+) -> Result<DiskSpaceInfo, AppError> {
+    let requested = absolute_requested_path(Path::new(&path));
+    let checked = nearest_existing_path(&requested)
+        .ok_or_else(|| AppError::Io(format!("No existing ancestor for path: {path}")))?;
+    let available_bytes = fs2::available_space(&checked)
+        .map_err(|e| AppError::Io(format!("Failed to query available disk space: {e}")))?;
+    let existing_file_sizes = existing_file_sizes(&requested, relative_paths);
+    log::debug!(
+        "disk-space: path={path:?} checked_path={:?} available_bytes={available_bytes} existing_files={}",
+        checked,
+        existing_file_sizes.len()
+    );
+    Ok(DiskSpaceInfo {
+        path,
+        checked_path: crate::engine::path_to_safe_string(&checked),
+        available_bytes,
+        existing_file_sizes,
+    })
 }
 
 /// Checks whether a file or directory exists at the given path.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -844,6 +844,7 @@ pub fn run() {
             commands::is_autostart_launch,
             commands::clear_log_file,
             commands::export_diagnostic_logs,
+            commands::get_available_disk_space,
             commands::check_path_exists,
             commands::check_path_is_dir,
             commands::read_local_file,

--- a/src/components/task/AddTask.vue
+++ b/src/components/task/AddTask.vue
@@ -25,6 +25,7 @@ import { isMagnetUri } from '@/composables/useMagnetFlow'
 import { open as openDialog } from '@tauri-apps/plugin-dialog'
 import { logger } from '@shared/logger'
 import { getErrorMessage } from '@shared/utils/errorMessage'
+import { isDiskSpaceError } from '@/composables/useDiskSpacePreflight'
 import { normalizeProxyMode } from '@shared/utils/proxyPolicy'
 import { resolveUserVisibleDownloadDir } from '@shared/utils/userVisibleDirectory'
 import { findMatchingUserAgentRule, resolveUserAgent } from '@shared/utils/userAgentPolicy'
@@ -529,7 +530,7 @@ async function handleSubmit() {
     let manualResult: ManualUriSubmitResult = { submittedTaskNames: [], magnetGids: [], magnetFailures: [] }
 
     if (hasBatch.value) {
-      await submitBatchItems(batch.value, options, taskStore)
+      await submitBatchItems(batch.value, options, taskStore, t)
     }
     if (form.value.uris.trim()) {
       // User's custom path takes highest priority — skip classification when overridden
@@ -610,6 +611,8 @@ async function handleSubmit() {
       message.error(t('app.engine-not-ready'), { closable: true })
     } else if (category === 'duplicate') {
       message.warning(errMsg, { closable: true })
+    } else if (category === 'disk-full' || isDiskSpaceError(e)) {
+      message.error(t('task.error-disk-full'), { closable: true })
     } else {
       message.error(errMsg, { closable: true })
     }
@@ -692,6 +695,7 @@ function kindTagType(kind: string): 'info' | 'success' | 'warning' {
                   >
                     <div class="batch-item-main">
                       <NEllipsis :style="{ maxWidth: '400px', flex: 1 }">{{ item.displayName }}</NEllipsis>
+                      <span v-if="item.error" class="batch-item-error">{{ item.error }}</span>
                       <NSpace :size="4" align="center" :wrap="false">
                         <NTag :type="kindTagType(item.kind)" size="small" :bordered="false"> Torrent </NTag>
                         <NButton quaternary size="tiny" @click.stop="removeBatchItem(item)">✕</NButton>
@@ -934,6 +938,15 @@ function kindTagType(kind: string): 'info' | 'success' | 'warning' {
   align-items: center;
   justify-content: space-between;
   gap: 8px;
+}
+.batch-item-error {
+  flex: 0 1 260px;
+  min-width: 0;
+  color: var(--m3-error);
+  font-size: var(--font-size-sm, 12px);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 /* ── Content crossfade (file detail switching) ────────────────────── */

--- a/src/composables/__tests__/useAddTaskSubmit.test.ts
+++ b/src/composables/__tests__/useAddTaskSubmit.test.ts
@@ -9,6 +9,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ref } from 'vue'
+import { invoke } from '@tauri-apps/api/core'
 
 // ── Mock external dependencies ──────────────────────────────────────
 vi.mock('@tauri-apps/api/core', () => ({
@@ -390,6 +391,12 @@ describe('classifySubmitError', () => {
     expect(classifySubmitError(new Error('duplicate download detected'))).toBe('duplicate')
   })
 
+  it('returns disk-full for disk allocation failures', () => {
+    expect(
+      classifySubmitError(new Error('Failed to write into the file, cause: There is not enough space on the disk.')),
+    ).toBe('disk-full')
+  })
+
   it('returns generic for unknown errors', () => {
     expect(classifySubmitError(new Error('network timeout'))).toBe('generic')
   })
@@ -505,6 +512,61 @@ describe('submitBatchItems', () => {
 
     expect(failures).toBe(1)
     expect(items[0].error).toBe('Aria2 Next error [1]: Unsupported URI scheme')
+  })
+
+  it('skips addTorrent when disk-space preflight fails', async () => {
+    ;(invoke as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      path: '/dl',
+      checkedPath: '/dl',
+      availableBytes: 100,
+      existingFileSizes: [],
+    })
+    const t = (key: string, params?: Record<string, unknown>) => `${key}:${params?.required}/${params?.available}`
+    const items: BatchItem[] = [
+      {
+        id: 'disk-full',
+        kind: 'torrent',
+        source: 'huge.torrent',
+        displayName: 'huge.torrent',
+        payload: 'b64',
+        status: 'pending',
+        selectedFileIndices: [1],
+        torrentMeta: { infoHash: 'abc', files: [{ idx: 1, path: 'huge.bin', length: 200 }] },
+      },
+    ]
+
+    const failures = await submitBatchItems(items, baseOptions, mockTaskStore, t)
+
+    expect(failures).toBe(1)
+    expect(mockTaskStore.addTorrent).not.toHaveBeenCalled()
+    expect(items[0].status).toBe('failed')
+    expect(items[0].error).toBe('task.error-disk-full-detail:200 B/100 B')
+  })
+
+  it('runs disk-space preflight even without a translation function', async () => {
+    ;(invoke as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      path: '/dl',
+      checkedPath: '/dl',
+      availableBytes: 100,
+      existingFileSizes: [],
+    })
+    const items: BatchItem[] = [
+      {
+        id: 'disk-full-fallback',
+        kind: 'torrent',
+        source: 'huge.torrent',
+        displayName: 'huge.torrent',
+        payload: 'b64',
+        status: 'pending',
+        torrentMeta: { infoHash: 'abc', files: [{ idx: 1, path: 'huge.bin', length: 200 }] },
+      },
+    ]
+
+    const failures = await submitBatchItems(items, baseOptions, mockTaskStore)
+
+    expect(failures).toBe(1)
+    expect(mockTaskStore.addTorrent).not.toHaveBeenCalled()
+    expect(items[0].error).toBe('Insufficient disk space: required 200 bytes, available 100 bytes')
   })
 
   it('skips already submitted items', async () => {

--- a/src/composables/__tests__/useDiskSpacePreflight.test.ts
+++ b/src/composables/__tests__/useDiskSpacePreflight.test.ts
@@ -1,0 +1,117 @@
+/** @fileoverview Tests for torrent disk-space preflight helpers. */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { invoke } from '@tauri-apps/api/core'
+import type { Aria2EngineOptions, BatchItem } from '@shared/types'
+import { checkTorrentDiskSpace, formatDiskSpaceError, isDiskSpaceError } from '../useDiskSpacePreflight'
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}))
+
+describe('useDiskSpacePreflight', () => {
+  const options: Aria2EngineOptions = { dir: '/downloads', split: '16' }
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('detects common disk-full error messages', () => {
+    expect(isDiskSpaceError(new Error('There is not enough space on the disk.'))).toBe(true)
+    expect(isDiskSpaceError({ Aria2: 'aria2 RPC error [9]: No space left on device' })).toBe(true)
+    expect(isDiskSpaceError(new Error('network timeout'))).toBe(false)
+  })
+
+  it('reports a preflight failure when selected torrent files exceed available space', async () => {
+    ;(invoke as ReturnType<typeof vi.fn>).mockResolvedValue({
+      path: '/downloads',
+      checkedPath: '/downloads',
+      availableBytes: 500,
+      existingFileSizes: [],
+    })
+    const item = {
+      id: '1',
+      kind: 'torrent',
+      source: 'large.torrent',
+      payload: 'base64',
+      displayName: 'large.torrent',
+      status: 'pending',
+      selectedFileIndices: [1, 3],
+      torrentMeta: {
+        infoHash: 'abc',
+        files: [
+          { idx: 1, path: 'a.bin', length: 400 },
+          { idx: 2, path: 'b.bin', length: 900 },
+          { idx: 3, path: 'c.bin', length: 200 },
+        ],
+      },
+    } as BatchItem
+
+    const failures = await checkTorrentDiskSpace([item], options)
+
+    expect(invoke).toHaveBeenCalledTimes(1)
+    expect(invoke).toHaveBeenCalledWith('get_available_disk_space', {
+      path: '/downloads',
+      relativePaths: ['a.bin', 'c.bin'],
+    })
+    expect(failures).toEqual([{ item, requiredBytes: 600, availableBytes: 500, dir: '/downloads' }])
+  })
+
+  it('tracks remaining free space across torrent batches with one IPC call', async () => {
+    ;(invoke as ReturnType<typeof vi.fn>).mockResolvedValue({
+      path: '/downloads',
+      checkedPath: '/downloads',
+      availableBytes: 1000,
+      existingFileSizes: [],
+    })
+    const first = {
+      id: 'first',
+      kind: 'torrent',
+      source: 'first.torrent',
+      payload: 'base64',
+      displayName: 'first.torrent',
+      status: 'pending',
+      torrentMeta: { infoHash: 'abc', files: [{ idx: 1, path: 'first.bin', length: 700 }] },
+    } as BatchItem
+    const second = {
+      id: 'second',
+      kind: 'torrent',
+      source: 'second.torrent',
+      payload: 'base64',
+      displayName: 'second.torrent',
+      status: 'pending',
+      torrentMeta: { infoHash: 'def', files: [{ idx: 1, path: 'second.bin', length: 500 }] },
+    } as BatchItem
+
+    const failures = await checkTorrentDiskSpace([first, second], options)
+
+    expect(invoke).toHaveBeenCalledTimes(1)
+    expect(failures).toEqual([{ item: second, requiredBytes: 500, availableBytes: 300, dir: '/downloads' }])
+  })
+
+  it('subtracts existing target file sizes before checking required space', async () => {
+    ;(invoke as ReturnType<typeof vi.fn>).mockResolvedValue({
+      path: '/downloads',
+      checkedPath: '/downloads',
+      availableBytes: 200,
+      existingFileSizes: [{ relativePath: 'movie.mkv', sizeBytes: 900 }],
+    })
+    const item = {
+      id: 'resume',
+      kind: 'torrent',
+      source: 'resume.torrent',
+      payload: 'base64',
+      displayName: 'resume.torrent',
+      status: 'pending',
+      torrentMeta: { infoHash: 'abc', files: [{ idx: 1, path: 'movie.mkv', length: 1000 }] },
+    } as BatchItem
+
+    const failures = await checkTorrentDiskSpace([item], options)
+
+    expect(failures).toEqual([])
+  })
+
+  it('formats localized preflight details', () => {
+    const t = (key: string, params?: Record<string, unknown>) => `${key}:${params?.required}/${params?.available}`
+    expect(formatDiskSpaceError(t, 1024 * 1024, 512)).toBe('task.error-disk-full-detail:1.0 MB/512 B')
+  })
+})

--- a/src/composables/useAddTaskSubmit.ts
+++ b/src/composables/useAddTaskSubmit.ts
@@ -44,6 +44,7 @@ import {
 } from '@shared/utils/headerSanitize'
 import { summarizeHeaderForwarding } from '@shared/utils/externalInputDiagnostics'
 import { getErrorMessage } from '@shared/utils/errorMessage'
+import { checkTorrentDiskSpace, formatDiskSpaceError, isDiskSpaceError } from '@/composables/useDiskSpacePreflight'
 import { buildTaskProxyOptions, getDownloadProxy, type TaskProxyMode } from '@shared/utils/proxyPolicy'
 import { resolveUserAgentFromContext } from '@shared/utils/userAgentPolicy'
 
@@ -160,10 +161,11 @@ function summarizeSubmitHeaderForwarding(form: AddTaskForm, context?: ExternalDo
  * Classifies an error from task submission into a user-friendly category.
  * Pure function — fully testable.
  */
-export function classifySubmitError(err: unknown): 'engine-not-ready' | 'duplicate' | 'generic' {
+export function classifySubmitError(err: unknown): 'engine-not-ready' | 'duplicate' | 'disk-full' | 'generic' {
   const msg = getErrorMessage(err)
   if (msg.includes('not initialized') || !isEngineReady()) return 'engine-not-ready'
   if (/duplicate|already/i.test(msg)) return 'duplicate'
+  if (isDiskSpaceError(err)) return 'disk-full'
   return 'generic'
 }
 
@@ -175,10 +177,28 @@ export async function submitBatchItems(
   items: BatchItem[],
   options: Aria2EngineOptions,
   taskStore: ReturnType<typeof useTaskStore>,
+  t?: (key: string, params?: Record<string, unknown>) => string,
 ): Promise<number> {
   let failures = 0
+  const preflightFailedIds = new Set<string>()
+  for (const failure of await checkTorrentDiskSpace(items, options)) {
+    preflightFailedIds.add(failure.item.id)
+    failure.item.status = 'failed'
+    failure.item.error = t
+      ? formatDiskSpaceError(t, failure.requiredBytes, failure.availableBytes)
+      : `Insufficient disk space: required ${failure.requiredBytes} bytes, available ${failure.availableBytes} bytes`
+    logger.warn(
+      'submitBatchItems.diskSpace',
+      `dir=${failure.dir} required=${failure.requiredBytes} available=${failure.availableBytes}`,
+    )
+  }
+
   for (const item of items) {
     if (item.kind === 'uri') continue
+    if (preflightFailedIds.has(item.id)) {
+      failures++
+      continue
+    }
     if (item.status !== 'pending' && item.status !== 'failed') continue
     try {
       if (item.kind === 'torrent') {
@@ -203,7 +223,7 @@ export async function submitBatchItems(
       logger.info('submitBatchItems', `${item.kind} submitted: ${item.displayName}`)
     } catch (e) {
       item.status = 'failed'
-      item.error = getErrorMessage(e)
+      item.error = t && isDiskSpaceError(e) ? t('task.error-disk-full') : getErrorMessage(e)
       logger.error('submitBatchItems', e)
       failures++
     }
@@ -370,7 +390,7 @@ export function useAddTaskSubmit({ form, onClose }: UseAddTaskSubmitOptions) {
       let manualResult: ManualUriSubmitResult = { submittedTaskNames: [], magnetGids: [], magnetFailures: [] }
 
       if (batch.length > 0) {
-        await submitBatchItems(batch, options, taskStore)
+        await submitBatchItems(batch, options, taskStore, t)
       }
       if (form.value.uris.trim()) {
         manualResult = await submitManualUris(
@@ -427,6 +447,8 @@ export function useAddTaskSubmit({ form, onClose }: UseAddTaskSubmitOptions) {
         message.error(t('app.engine-not-ready'), { closable: true })
       } else if (category === 'duplicate') {
         message.warning(errMsg, { closable: true })
+      } else if (category === 'disk-full') {
+        message.error(t('task.error-disk-full'), { closable: true })
       } else {
         message.error(errMsg, { closable: true })
       }

--- a/src/composables/useDiskSpacePreflight.ts
+++ b/src/composables/useDiskSpacePreflight.ts
@@ -1,0 +1,120 @@
+/** @fileoverview Torrent disk-space preflight utilities for AddTask submissions. */
+import { invoke } from '@tauri-apps/api/core'
+import type { Aria2EngineOptions, BatchItem } from '@shared/types'
+import { bytesToSize } from '@shared/utils/format'
+import { getErrorMessage } from '@shared/utils/errorMessage'
+import { logger } from '@shared/logger'
+
+interface ExistingFileSize {
+  relativePath: string
+  sizeBytes: number
+}
+
+interface DiskSpaceInfo {
+  path: string
+  checkedPath: string
+  availableBytes: number
+  existingFileSizes?: ExistingFileSize[]
+}
+
+export interface DiskSpaceFailure {
+  item: BatchItem
+  requiredBytes: number
+  availableBytes: number
+  dir: string
+}
+
+const DISK_FULL_PATTERNS = [
+  /errorCode\s*=\s*9/i,
+  /\berror\s*\[9\]/i,
+  /not enough (?:free )?space/i,
+  /no space left/i,
+  /disk(?: is)? full/i,
+  /insufficient disk space/i,
+  /enospc/i,
+  /ERROR_DISK_FULL/i,
+  /err(?:or)?\s*(?:num(?:ber)?|no)?\s*=?\s*112/i,
+]
+
+function selectedTorrentFiles(item: BatchItem): NonNullable<BatchItem['torrentMeta']>['files'] {
+  const files = item.torrentMeta?.files ?? []
+  if (files.length === 0) return []
+  const selected = new Set(item.selectedFileIndices ?? files.map((file) => file.idx))
+  return files.filter((file) => selected.has(file.idx) && typeof file.path === 'string' && file.length > 0)
+}
+
+function selectedTorrentBytes(item: BatchItem, existingSizes: ReadonlyMap<string, number>): number | null {
+  const selectedFiles = selectedTorrentFiles(item)
+  if (selectedFiles.length === 0) return null
+  return selectedFiles.reduce((total, file) => {
+    const existingBytes = existingSizes.get(file.path) ?? 0
+    return total + Math.max(file.length - existingBytes, 0)
+  }, 0)
+}
+
+function torrentFilePaths(items: BatchItem[]): string[] {
+  const uniquePaths = new Set<string>()
+  for (const item of items) {
+    if (item.kind !== 'torrent' || (item.status !== 'pending' && item.status !== 'failed')) continue
+    for (const file of selectedTorrentFiles(item)) {
+      uniquePaths.add(file.path)
+    }
+  }
+  return [...uniquePaths]
+}
+
+export function isDiskSpaceError(error: unknown): boolean {
+  const message = getErrorMessage(error)
+  return DISK_FULL_PATTERNS.some((pattern) => pattern.test(message))
+}
+
+export function formatDiskSpaceError(
+  t: (key: string, params?: Record<string, unknown>) => string,
+  requiredBytes: number,
+  availableBytes: number,
+): string {
+  return t('task.error-disk-full-detail', {
+    required: bytesToSize(requiredBytes),
+    available: bytesToSize(availableBytes),
+  })
+}
+
+export async function checkTorrentDiskSpace(
+  items: BatchItem[],
+  options: Aria2EngineOptions,
+): Promise<DiskSpaceFailure[]> {
+  const failures: DiskSpaceFailure[] = []
+  const dir = typeof options.dir === 'string' ? options.dir.trim() : ''
+  if (!dir) return failures
+
+  const relativePaths = torrentFilePaths(items)
+  if (relativePaths.length === 0) return failures
+
+  let info: DiskSpaceInfo
+  try {
+    info = await invoke<DiskSpaceInfo>('get_available_disk_space', {
+      path: dir,
+      relativePaths,
+    })
+  } catch (error) {
+    logger.warn('DiskSpacePreflight', getErrorMessage(error))
+    return failures
+  }
+
+  const existingSizes = new Map((info.existingFileSizes ?? []).map((file) => [file.relativePath, file.sizeBytes]))
+  let remainingBytes = info.availableBytes
+
+  for (const item of items) {
+    if (item.kind !== 'torrent' || (item.status !== 'pending' && item.status !== 'failed')) continue
+    const requiredBytes = selectedTorrentBytes(item, existingSizes)
+    if (requiredBytes === null || requiredBytes <= 0) continue
+
+    if (remainingBytes < requiredBytes) {
+      failures.push({ item, requiredBytes, availableBytes: remainingBytes, dir: info.path })
+      continue
+    }
+    remainingBytes -= requiredBytes
+  }
+
+  return failures
+}

--- a/src/shared/locales/ar/task.js
+++ b/src/shared/locales/ar/task.js
@@ -100,6 +100,7 @@ export default {
   'error-network': 'Network error',
   'error-unfinished': 'Unfinished downloads remain',
   'error-resume-failed': 'Server does not support resume',
+  'error-disk-full-detail': 'مساحة القرص الهدف غير كافية. تحتاج هذه المهمة إلى حوالي {required}، والمساحة المتاحة {available}. يرجى إخلاء مساحة أو تغيير مجلد التنزيل.',
   'error-disk-full': 'Not enough disk space',
   'error-piece-length': 'Piece length mismatch with control file',
   'error-duplicate-file': 'Already downloading this file',

--- a/src/shared/locales/bg/task.js
+++ b/src/shared/locales/bg/task.js
@@ -100,6 +100,7 @@ export default {
   'error-network': 'Network error',
   'error-unfinished': 'Unfinished downloads remain',
   'error-resume-failed': 'Server does not support resume',
+  'error-disk-full-detail': 'Няма достатъчно място на целевия диск. Тази задача изисква около {required}, налични са {available}. Освободете място или сменете папката за изтегляне.',
   'error-disk-full': 'Not enough disk space',
   'error-piece-length': 'Piece length mismatch with control file',
   'error-duplicate-file': 'Already downloading this file',

--- a/src/shared/locales/ca/task.js
+++ b/src/shared/locales/ca/task.js
@@ -100,6 +100,7 @@ export default {
   'error-network': 'Network error',
   'error-unfinished': 'Unfinished downloads remain',
   'error-resume-failed': 'Server does not support resume',
+  'error-disk-full-detail': 'No hi ha prou espai al disc de destinació. Aquesta tasca necessita aproximadament {required} i hi ha {available} disponibles. Allibereu espai o canvieu la carpeta de baixades.',
   'error-disk-full': 'Not enough disk space',
   'error-piece-length': 'Piece length mismatch with control file',
   'error-duplicate-file': 'Already downloading this file',

--- a/src/shared/locales/de/task.js
+++ b/src/shared/locales/de/task.js
@@ -100,6 +100,7 @@ export default {
   'error-network': 'Network error',
   'error-unfinished': 'Unfinished downloads remain',
   'error-resume-failed': 'Server does not support resume',
+  'error-disk-full-detail': 'Auf dem Ziellaufwerk ist nicht genügend Speicherplatz vorhanden. Diese Aufgabe benötigt etwa {required}, verfügbar sind {available}. Bitte geben Sie Speicherplatz frei oder ändern Sie den Download-Ordner.',
   'error-disk-full': 'Not enough disk space',
   'error-piece-length': 'Piece length mismatch with control file',
   'error-duplicate-file': 'Already downloading this file',

--- a/src/shared/locales/el/task.js
+++ b/src/shared/locales/el/task.js
@@ -100,6 +100,7 @@ export default {
   'error-network': 'Network error',
   'error-unfinished': 'Unfinished downloads remain',
   'error-resume-failed': 'Server does not support resume',
+  'error-disk-full-detail': 'Δεν υπάρχει αρκετός χώρος στον δίσκο προορισμού. Αυτή η εργασία χρειάζεται περίπου {required}, διαθέσιμα {available}. Ελευθερώστε χώρο ή αλλάξτε φάκελο λήψης.',
   'error-disk-full': 'Not enough disk space',
   'error-piece-length': 'Piece length mismatch with control file',
   'error-duplicate-file': 'Already downloading this file',

--- a/src/shared/locales/en-US/task.js
+++ b/src/shared/locales/en-US/task.js
@@ -100,6 +100,7 @@ export default {
   'error-network': 'Network error',
   'error-unfinished': 'Unfinished downloads remain',
   'error-resume-failed': 'Server does not support resume',
+  'error-disk-full-detail': 'Target disk space is insufficient. This task needs about {required}; {available} is available. Free up space or change the download directory.',
   'error-disk-full': 'Not enough disk space',
   'error-piece-length': 'Piece length mismatch with control file',
   'error-duplicate-file': 'Already downloading this file',

--- a/src/shared/locales/es/task.js
+++ b/src/shared/locales/es/task.js
@@ -100,6 +100,7 @@ export default {
   'error-network': 'Network error',
   'error-unfinished': 'Unfinished downloads remain',
   'error-resume-failed': 'Server does not support resume',
+  'error-disk-full-detail': 'No hay suficiente espacio en el disco de destino. Esta tarea necesita aproximadamente {required}; hay {available} disponibles. Libera espacio o cambia la carpeta de descargas.',
   'error-disk-full': 'Not enough disk space',
   'error-piece-length': 'Piece length mismatch with control file',
   'error-duplicate-file': 'Already downloading this file',

--- a/src/shared/locales/fa/task.js
+++ b/src/shared/locales/fa/task.js
@@ -100,6 +100,7 @@ export default {
   'error-network': 'Network error',
   'error-unfinished': 'Unfinished downloads remain',
   'error-resume-failed': 'Server does not support resume',
+  'error-disk-full-detail': 'فضای دیسک مقصد کافی نیست. این وظیفه به حدود {required} نیاز دارد و {available} در دسترس است. فضا را خالی کنید یا پوشه دانلود را تغییر دهید.',
   'error-disk-full': 'Not enough disk space',
   'error-piece-length': 'Piece length mismatch with control file',
   'error-duplicate-file': 'Already downloading this file',

--- a/src/shared/locales/fr/task.js
+++ b/src/shared/locales/fr/task.js
@@ -100,6 +100,7 @@ export default {
   'error-network': 'Network error',
   'error-unfinished': 'Unfinished downloads remain',
   'error-resume-failed': 'Server does not support resume',
+  'error-disk-full-detail': 'L’espace disque cible est insuffisant. Cette tâche nécessite environ {required}, et {available} sont disponibles. Libérez de l’espace ou changez le dossier de téléchargement.',
   'error-disk-full': 'Not enough disk space',
   'error-piece-length': 'Piece length mismatch with control file',
   'error-duplicate-file': 'Already downloading this file',

--- a/src/shared/locales/hi/task.js
+++ b/src/shared/locales/hi/task.js
@@ -100,6 +100,7 @@ export default {
   'error-network': 'Network error',
   'error-unfinished': 'अधूरे downloads बचे हैं',
   'error-resume-failed': 'Server resume support नहीं करता',
+  'error-disk-full-detail': 'लक्षित डिस्क में पर्याप्त जगह नहीं है। इस कार्य को लगभग {required} चाहिए; {available} उपलब्ध है। जगह खाली करें या डाउनलोड फ़ोल्डर बदलें।',
   'error-disk-full': 'Disk space पर्याप्त नहीं है',
   'error-piece-length': 'Piece length control file से match नहीं करती',
   'error-duplicate-file': 'यह file पहले से download हो रही है',

--- a/src/shared/locales/hu/task.js
+++ b/src/shared/locales/hu/task.js
@@ -100,6 +100,7 @@ export default {
   'error-network': 'Network error',
   'error-unfinished': 'Unfinished downloads remain',
   'error-resume-failed': 'Server does not support resume',
+  'error-disk-full-detail': 'Nincs elég hely a céllemezen. Ehhez a feladathoz körülbelül {required} szükséges, elérhető: {available}. Szabadítson fel helyet, vagy módosítsa a letöltési mappát.',
   'error-disk-full': 'Not enough disk space',
   'error-piece-length': 'Piece length mismatch with control file',
   'error-duplicate-file': 'Already downloading this file',

--- a/src/shared/locales/id/task.js
+++ b/src/shared/locales/id/task.js
@@ -100,6 +100,7 @@ export default {
   'error-network': 'Network error',
   'error-unfinished': 'Unfinished downloads remain',
   'error-resume-failed': 'Server does not support resume',
+  'error-disk-full-detail': 'Ruang disk tujuan tidak mencukupi. Tugas ini membutuhkan sekitar {required}; tersedia {available}. Kosongkan ruang atau ubah folder unduhan.',
   'error-disk-full': 'Not enough disk space',
   'error-piece-length': 'Piece length mismatch with control file',
   'error-duplicate-file': 'Already downloading this file',

--- a/src/shared/locales/it/task.js
+++ b/src/shared/locales/it/task.js
@@ -100,6 +100,7 @@ export default {
   'error-network': 'Network error',
   'error-unfinished': 'Unfinished downloads remain',
   'error-resume-failed': 'Server does not support resume',
+  'error-disk-full-detail': 'Lo spazio sul disco di destinazione non è sufficiente. Questa attività richiede circa {required}; disponibili {available}. Libera spazio o cambia cartella di download.',
   'error-disk-full': 'Not enough disk space',
   'error-piece-length': 'Piece length mismatch with control file',
   'error-duplicate-file': 'Already downloading this file',

--- a/src/shared/locales/ja/task.js
+++ b/src/shared/locales/ja/task.js
@@ -100,6 +100,7 @@ export default {
   'error-network': 'ネットワークエラー',
   'error-unfinished': '未完了のダウンロードがあります',
   'error-resume-failed': 'サーバーがレジュームをサポートしていません',
+  'error-disk-full-detail': '保存先ディスクの空き容量が不足しています。このタスクには約 {required} が必要ですが、利用可能なのは {available} です。空き容量を増やすか、ダウンロード先を変更してください。',
   'error-disk-full': 'ディスク容量が不足しています',
   'error-piece-length': 'ピース長が制御ファイルと一致しません',
   'error-duplicate-file': '同じファイルをダウンロード中です',

--- a/src/shared/locales/ko/task.js
+++ b/src/shared/locales/ko/task.js
@@ -100,6 +100,7 @@ export default {
   'error-network': '네트워크 오류',
   'error-unfinished': '완료되지 않은 다운로드가 있음',
   'error-resume-failed': '서버가 이어받기를 지원하지 않음',
+  'error-disk-full-detail': '대상 디스크 공간이 부족합니다. 이 작업에는 약 {required}이(가) 필요하며 사용 가능 공간은 {available}입니다. 공간을 확보하거나 다운로드 폴더를 변경하세요.',
   'error-disk-full': '디스크 공간 부족',
   'error-piece-length': '조각 길이가 제어 파일과 일치하지 않음',
   'error-duplicate-file': '동일한 파일을 다운로드 중',

--- a/src/shared/locales/nb/task.js
+++ b/src/shared/locales/nb/task.js
@@ -100,6 +100,7 @@ export default {
   'error-network': 'Network error',
   'error-unfinished': 'Unfinished downloads remain',
   'error-resume-failed': 'Server does not support resume',
+  'error-disk-full-detail': 'Det er ikke nok plass på måldisken. Denne oppgaven trenger omtrent {required}; {available} er tilgjengelig. Frigjør plass eller endre nedlastingsmappe.',
   'error-disk-full': 'Not enough disk space',
   'error-piece-length': 'Piece length mismatch with control file',
   'error-duplicate-file': 'Already downloading this file',

--- a/src/shared/locales/nl/task.js
+++ b/src/shared/locales/nl/task.js
@@ -100,6 +100,7 @@ export default {
   'error-network': 'Network error',
   'error-unfinished': 'Unfinished downloads remain',
   'error-resume-failed': 'Server does not support resume',
+  'error-disk-full-detail': 'Er is onvoldoende ruimte op de doelschijf. Deze taak heeft ongeveer {required} nodig; {available} is beschikbaar. Maak ruimte vrij of wijzig de downloadmap.',
   'error-disk-full': 'Not enough disk space',
   'error-piece-length': 'Piece length mismatch with control file',
   'error-duplicate-file': 'Already downloading this file',

--- a/src/shared/locales/pl/task.js
+++ b/src/shared/locales/pl/task.js
@@ -100,6 +100,7 @@ export default {
   'error-network': 'Network error',
   'error-unfinished': 'Unfinished downloads remain',
   'error-resume-failed': 'Server does not support resume',
+  'error-disk-full-detail': 'Na dysku docelowym nie ma wystarczającej ilości miejsca. To zadanie wymaga około {required}, dostępne jest {available}. Zwolnij miejsce lub zmień folder pobierania.',
   'error-disk-full': 'Not enough disk space',
   'error-piece-length': 'Piece length mismatch with control file',
   'error-duplicate-file': 'Already downloading this file',

--- a/src/shared/locales/pt-BR/task.js
+++ b/src/shared/locales/pt-BR/task.js
@@ -100,6 +100,7 @@ export default {
   'error-network': 'Network error',
   'error-unfinished': 'Unfinished downloads remain',
   'error-resume-failed': 'Server does not support resume',
+  'error-disk-full-detail': 'Não há espaço suficiente no disco de destino. Esta tarefa precisa de cerca de {required}; há {available} disponível. Libere espaço ou altere a pasta de downloads.',
   'error-disk-full': 'Not enough disk space',
   'error-piece-length': 'Piece length mismatch with control file',
   'error-duplicate-file': 'Already downloading this file',

--- a/src/shared/locales/ro/task.js
+++ b/src/shared/locales/ro/task.js
@@ -100,6 +100,7 @@ export default {
   'error-network': 'Network error',
   'error-unfinished': 'Unfinished downloads remain',
   'error-resume-failed': 'Server does not support resume',
+  'error-disk-full-detail': 'Spațiul de pe discul țintă este insuficient. Această sarcină necesită aproximativ {required}, iar disponibil este {available}. Eliberați spațiu sau schimbați folderul de descărcare.',
   'error-disk-full': 'Not enough disk space',
   'error-piece-length': 'Piece length mismatch with control file',
   'error-duplicate-file': 'Already downloading this file',

--- a/src/shared/locales/ru/task.js
+++ b/src/shared/locales/ru/task.js
@@ -100,6 +100,7 @@ export default {
   'error-network': 'Network error',
   'error-unfinished': 'Unfinished downloads remain',
   'error-resume-failed': 'Server does not support resume',
+  'error-disk-full-detail': 'На целевом диске недостаточно места. Для этой задачи требуется около {required}, доступно {available}. Освободите место или измените папку загрузки.',
   'error-disk-full': 'Not enough disk space',
   'error-piece-length': 'Piece length mismatch with control file',
   'error-duplicate-file': 'Already downloading this file',

--- a/src/shared/locales/th/task.js
+++ b/src/shared/locales/th/task.js
@@ -100,6 +100,7 @@ export default {
   'error-network': 'Network error',
   'error-unfinished': 'Unfinished downloads remain',
   'error-resume-failed': 'Server does not support resume',
+  'error-disk-full-detail': 'พื้นที่ดิสก์ปลายทางไม่เพียงพอ งานนี้ต้องใช้ประมาณ {required} มีพื้นที่ว่าง {available} โปรดเพิ่มพื้นที่ว่างหรือเปลี่ยนโฟลเดอร์ดาวน์โหลด',
   'error-disk-full': 'Not enough disk space',
   'error-piece-length': 'Piece length mismatch with control file',
   'error-duplicate-file': 'Already downloading this file',

--- a/src/shared/locales/tr/task.js
+++ b/src/shared/locales/tr/task.js
@@ -100,6 +100,7 @@ export default {
   'error-network': 'Network error',
   'error-unfinished': 'Unfinished downloads remain',
   'error-resume-failed': 'Server does not support resume',
+  'error-disk-full-detail': 'Hedef diskte yeterli alan yok. Bu görev yaklaşık {required} gerektiriyor; kullanılabilir alan {available}. Alan açın veya indirme klasörünü değiştirin.',
   'error-disk-full': 'Not enough disk space',
   'error-piece-length': 'Piece length mismatch with control file',
   'error-duplicate-file': 'Already downloading this file',

--- a/src/shared/locales/uk/task.js
+++ b/src/shared/locales/uk/task.js
@@ -100,6 +100,7 @@ export default {
   'error-network': 'Network error',
   'error-unfinished': 'Unfinished downloads remain',
   'error-resume-failed': 'Server does not support resume',
+  'error-disk-full-detail': 'На цільовому диску недостатньо місця. Для цього завдання потрібно приблизно {required}, доступно {available}. Звільніть місце або змініть теку завантаження.',
   'error-disk-full': 'Not enough disk space',
   'error-piece-length': 'Piece length mismatch with control file',
   'error-duplicate-file': 'Already downloading this file',

--- a/src/shared/locales/vi/task.js
+++ b/src/shared/locales/vi/task.js
@@ -100,6 +100,7 @@ export default {
   'error-network': 'Network error',
   'error-unfinished': 'Unfinished downloads remain',
   'error-resume-failed': 'Server does not support resume',
+  'error-disk-full-detail': 'Ổ đĩa đích không đủ dung lượng. Tác vụ này cần khoảng {required}; hiện có {available}. Hãy giải phóng dung lượng hoặc đổi thư mục tải xuống.',
   'error-disk-full': 'Not enough disk space',
   'error-piece-length': 'Piece length mismatch with control file',
   'error-duplicate-file': 'Already downloading this file',

--- a/src/shared/locales/zh-CN/task.js
+++ b/src/shared/locales/zh-CN/task.js
@@ -100,6 +100,7 @@ export default {
   'error-network': '网络错误',
   'error-unfinished': '存在未完成的下载',
   'error-resume-failed': '服务器不支持断点续传',
+  'error-disk-full-detail': '目标磁盘空间不足。该任务需要约 {required}，可用空间 {available}。请清理磁盘或更改下载目录。',
   'error-disk-full': '磁盘空间不足',
   'error-piece-length': '分片长度与控制文件不匹配',
   'error-duplicate-file': '正在下载相同的文件',

--- a/src/shared/locales/zh-TW/task.js
+++ b/src/shared/locales/zh-TW/task.js
@@ -100,6 +100,7 @@ export default {
   'error-network': '網路錯誤',
   'error-unfinished': '存在未完成的下載',
   'error-resume-failed': '伺服器不支援斷點續傳',
+  'error-disk-full-detail': '目標磁碟空間不足。此任務需要約 {required}，可用空間 {available}。請清理磁碟或變更下載目錄。',
   'error-disk-full': '磁碟空間不足',
   'error-piece-length': '分片長度與控制檔案不匹配',
   'error-duplicate-file': '正在下載相同的檔案',


### PR DESCRIPTION
Description

Fixes #400

This PR fixes a missing error-handling path when a download cannot start because the target disk does not have enough free space.

Previously, aria2 could fail during file allocation with errors such as “There is not enough space on the disk”, but the failure was not surfaced properly to the user. From the UI perspective, the task appeared to remain pending or simply failed to start without a clear explanation.

This change adds a disk-space preflight check before task submission and provides a clear user-facing error when insufficient free space is detected.

Type of change

* Bug fix (non-breaking change that fixes an issue)
* New feature (must be discussed and approved in an issue first)
* Refactor (no functional change)
* Documentation / i18n
* CI / build configuration

How has this been tested?

Tested locally by simulating insufficient disk space conditions and verifying that the download submission flow reports a clear error instead of silently failing.

Additional unit tests were added for the disk-space preflight logic and task submission flow.

The following commands were executed successfully:

pnpm format:check
npx vue-tsc --noEmit
pnpm test
cd src-tauri && cargo test

AI usage disclosure

* No AI tools were used
* AI tools assisted with drafting, refactoring, or boilerplate (I reviewed and understand every line)
* Substantial portions were AI-generated (I reviewed, tested, and can explain every change)

If AI was used, specify the tool: ChatGPT

Checklist

Required — PR will not be reviewed without these

* I have read https://github.com/AnInsomniacy/motrix-next/blob/main/docs/CONTRIBUTING.md
* PR changes fewer than 300 lines of code (excluding tests and generated files)
* PR touches fewer than 10 files
* PR addresses one concern only — no mixed features, config tweaks, or unrelated fixes
* All commands pass locally:

pnpm format:check
npx vue-tsc --noEmit
pnpm test
cd src-tauri && cargo test

* Commits follow Conventional Commits format

If applicable

* New feature was discussed and approved in an issue before implementation
* Tests written before implementation (TDD: red → green → refactor)
* i18n keys updated in all locales via batch script
* New config key follows the full checklist in AGENTS.md §C
* Rust changes compile with cargo clippy (zero warnings)

Release notes

Show a clear error message when a download cannot start because the destination disk does not have enough free space.