### PR TITLE
build(macos): enable ad-hoc code signing for macOS bundles

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -52,6 +52,9 @@
         "role": "Viewer"
       }
     ],
+    "macOS": {
+      "signingIdentity": "-"
+    },
     "windows": {
       "nsis": {
         "installerIcon": "icons/icon.ico",


### PR DESCRIPTION
## Description

为 macOS 构建增加 Tauri 官方支持的 ad-hoc signing 配置：

```json
{
  "bundle": {
    "macOS": {
      "signingIdentity": "-"
    }
  }
}
```

该配置用于在没有 Apple Developer ID 证书的情况下，对 macOS App 进行临时签名。

关联 issue：Refs #203

### 背景

部分 macOS 用户下载应用后会遇到：

> "MotrixNext.app"已损坏，无法打开。你应该将它移到废纸篓。

这通常不是应用真的损坏，而是 macOS Gatekeeper 对未签名或签名状态异常的应用进行拦截。Tauri 官方文档说明 macOS 应用需要进行 code signing，对于没有 Apple 认证签名身份的项目，Tauri 支持 ad-hoc signing，配置方式即 `"signingIdentity": "-"`。

参考：https://v2.tauri.app/distribute/sign/macos/

### 本次改动

- 不引入 Apple Developer ID 签名，也不引入 notarization 公证流程
- 仅增加 Tauri 官方支持的 ad-hoc signing 配置，让 macOS 构建产物至少具备一个临时签名，减少被 Gatekeeper 直接判定为"已损坏"的概率

### 用户影响

改善 macOS 用户下载后打开应用的体验，减少"应用已损坏，无法打开"这类提示。

需要说明的是，ad-hoc signing 并不等同于 Apple Developer ID 签名，也不会让应用变成"已验证的开发者"。用户仍可能看到"无法验证开发者"提示，需要在「系统设置 → 隐私与安全性 → 仍要打开」中手动允许。

参考：https://support.apple.com/zh-cn/guide/mac-help/mh40616/mac

### 验证方式

本地构建：

```bash
pnpm tauri build
```

检查签名信息：

```bash
codesign -dv --verbose=4 "src-tauri/target/release/bundle/macos/MotrixNext.app"
```

预期可以看到 `Signature=adhoc`。

检查签名完整性：

```bash
codesign --verify --deep --strict --verbose=2 "src-tauri/target/release/bundle/macos/MotrixNext.app"
```

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (**must** be discussed and approved in an issue first)
- [ ] Refactor (no functional change)
- [ ] Documentation / i18n
- [x] CI / build configuration

## How has this been tested?

- [ ] Frontend checks passed: `pnpm format:check`, `npx vue-tsc --noEmit`, `pnpm test`
- [ ] Rust checks passed: `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo check --all-targets`, `cargo test --all-targets`
- [x] Manual testing completed, or not needed for this change

Unchecked checks:

- N/A: 无前端代码改动（仅 `tauri.conf.json` 的 bundle 配置变更）
- N/A: 无 Rust 代码改动（仅 `tauri.conf.json` 的 bundle 配置变更）
- 已通过 `prettier --check src-tauri/tauri.conf.json` 验证 JSON 格式符合项目风格

## AI usage disclosure

- [ ] No AI tools were used
- [x] AI tools assisted with drafting, refactoring, or boilerplate (I reviewed and understand every line)
- [ ] Substantial portions were AI-generated (I reviewed, tested, and can explain every change)

AI model: GPT5.5-xhigh + GLM-5.2

说明：本 PR 由两个 AI 模型协作完成：

- **GPT5.5-xhigh**：提出 ad-hoc signing 方案（包括 `signingIdentity: "-"` 配置项、背景调研、Tauri 官方文档引用与验证步骤）
- **GLM-5.2**：负责具体执行（fork 仓库、修改 `tauri.conf.json`、按 PR 模板起草描述、提交 commit、创建并更新 PR）

本人已逐行审阅并确认配置改动符合 Tauri 官方文档。

## Checklist

- [x] I kept this PR template complete and understand incomplete PRs may be closed without review
- [x] I have read [CONTRIBUTING.md](https://github.com/AnInsomniacy/motrix-next/blob/main/docs/CONTRIBUTING.md)
- [x] This PR is focused, under the documented size limits, and uses Conventional Commits
- [x] Tests were added or updated for risky logic changes, or this PR explains why tests are not needed

N/A：单行配置变更，无逻辑代码改动，无需新增测试。

## Release notes

Notes: 通过启用 Tauri 官方支持的 ad-hoc signing，减少 macOS 用户下载后遇到"应用已损坏，无法打开"提示的概率。
