### PR TITLE
fix(macos): skip redundant autostart enable

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -277,23 +277,30 @@ if (import.meta.env.PROD) {
   /**
    * Sync autostart state with persisted preference.
    *
-   * When `openAtLogin` is true we **always** call `enable()`, even if
-   * `isEnabled()` reports true.  This is a deliberate workaround for
-   * auto-launch crate v0.5.0 bug: on Windows the registry entry under
-   * `HKCU\...\Run` is sometimes removed after the first successful
-   * launch (tauri-apps/plugins-workspace#771).  Re-calling `enable()`
-   * is idempotent and guarantees the entry + `--autostart` args are
-   * present for the next boot.
+   * Windows keeps re-calling `enable()` to self-heal auto-launch crate
+   * v0.5.0 registry loss after first boot (tauri-apps/plugins-workspace#771).
+   * macOS skips redundant `enable()` calls because rewriting the LaunchAgent
+   * can make the OS show "Background Items Added" on every app launch.
    */
   async function syncAutostart(config: typeof preferenceStore.config): Promise<void> {
     try {
       const { isEnabled, enable, disable } = await import('@tauri-apps/plugin-autostart')
       const currentlyEnabled = await isEnabled()
+      let isMac = false
+      try {
+        const { platform } = await import('@tauri-apps/plugin-os')
+        isMac = platform() === 'macos'
+      } catch (e) {
+        logger.debug('main.autostart.platform', e)
+      }
 
       if (config.openAtLogin) {
-        // Always re-enable to self-heal the registry (#771 workaround).
-        await enable()
-        logger.info('main.autostart', `ensured enabled (was=${currentlyEnabled} openAtLogin=${config.openAtLogin})`)
+        if (!isMac || !currentlyEnabled) {
+          await enable()
+          logger.info('main.autostart', `ensured enabled (was=${currentlyEnabled} openAtLogin=${config.openAtLogin})`)
+        } else {
+          logger.info('main.autostart', 'already enabled on macOS')
+        }
       } else if (currentlyEnabled) {
         await disable()
         logger.info('main.autostart', 'disabled (openAtLogin=false)')


### PR DESCRIPTION
## Description

Avoid re-running the Tauri autostart `enable()` call on macOS when Open at login is already enabled. Rewriting the LaunchAgent can make macOS show the "Background Items Added" notification on every app launch, while Windows still keeps the existing repeated `enable()` self-heal behavior for the auto-launch registry issue.

No linked issue; reported from macOS startup behavior.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (**must** be discussed and approved in an issue first)
- [ ] Refactor (no functional change)
- [ ] Documentation / i18n
- [ ] CI / build configuration

## How has this been tested?

- [x] Frontend checks passed: `pnpm format:check`, `npx vue-tsc --noEmit`, `pnpm test`
- [x] Rust checks passed: `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo check --all-targets`, `cargo test --all-targets`
- [x] Manual testing completed, or not needed for this change

Additional checks run:

- `pnpm format`
- `pnpm lint`
- `pnpm tauri build --target x86_64-apple-darwin` produced an Intel `.app`/`.dmg`; local updater signing was skipped because no `TAURI_SIGNING_PRIVATE_KEY` is configured.

Unchecked checks:

N/A.

## AI usage disclosure

- [ ] No AI tools were used
- [x] AI tools assisted with drafting, refactoring, or boilerplate (I reviewed and understand every line)
- [ ] Substantial portions were AI-generated (I reviewed, tested, and can explain every change)

AI model:

OpenAI GPT-5

## Checklist

- [x] I kept this PR template complete and understand incomplete PRs may be closed without review
- [x] I have read [CONTRIBUTING.md](https://github.com/AnInsomniacy/motrix-next/blob/main/docs/CONTRIBUTING.md)
- [x] This PR is focused, under the documented size limits, and uses Conventional Commits
- [x] Tests were added or updated for risky logic changes, or this PR explains why tests are not needed

No new tests were added because this is a single platform guard in startup autostart sync; the existing full frontend/Rust check suites and macOS Intel build cover regression risk for this low-risk change.

## Release notes

Avoid repeated macOS background item notifications when Open at login is already enabled.
